### PR TITLE
Prep for Claude Code plugin directory: unique slug, LICENSE, privacy section

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "plugins": [
     {
-      "name": "langfuse",
+      "name": "langfuse-observability",
       "source": "./",
       "description": "Trace Claude Code sessions to Langfuse"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "langfuse",
+  "name": "langfuse-observability",
   "description": "The Langfuse x Claude Code Observability Plugin",
   "version": "1.0.0",
   "author": {

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Langfuse
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,16 @@
 
   MIT
 ```
+
+## Privacy
+
+This plugin transmits your Claude Code session data — conversation turns, assistant
+generations, tool calls, and token-usage statistics — to the Langfuse endpoint you
+configure (`LANGFUSE_BASE_URL`, default `https://us.cloud.langfuse.com`; EU and
+self-hosted endpoints are supported). Data is sent at the end of each session (the
+`Stop` hook) using the Langfuse API keys you provide, which are stored in your OS
+keychain. No data is sent anywhere other than the endpoint you configure.
+
+For how Langfuse Cloud handles data it receives, see the Langfuse privacy policy:
+https://langfuse.com/privacy . When using a self-hosted Langfuse instance, your data
+stays within your own infrastructure.


### PR DESCRIPTION
A few small changes to get this ready for listing in the Claude Code plugin directory:

- **Rename the plugin to `langfuse-observability`** (`plugin.json` + `marketplace.json`). The bare name `langfuse` is already taken by the Langfuse skills plugin, so the two need distinct names to coexist — and this matches the name your `marketplace.json` already uses.
- **Add a `LICENSE` file** (MIT, matching the `license` field already declared in `plugin.json`).
- **Add a Privacy section to the README** describing what session data is sent and to which (user-configured, self-hostable) endpoint, with a link to the Langfuse privacy policy. This makes the data flow clear to users installing from the directory.

No functional/runtime changes — the hook behavior is unchanged. Happy to adjust the LICENSE copyright holder to your preferred legal entity.