### PR TITLE
Fix logging for parallel tool calls in Langfuse hook

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -415,6 +415,23 @@ class Turn:
     # belongs to, taken from isMeta rows carrying sourceToolUseID.
     injected_by_tool_id: Dict[str, str]
 
+
+def merge_assistant_content(base: Dict[str, Any], extra: Dict[str, Any]) -> None:
+    """
+    Append extra's content blocks onto bases's, in place.
+    Claude Code emits one logical assistant message (shared message.id) as several transcript rows.
+    We keep the first row as base and concatenate later rows' content blocks so all tool_use blocks
+    are preserved. Text/usage already match across rows, so base's metadata (model, usage, timestamp)
+    is left untouched.
+    """
+    
+    bc = get_content(base)
+    ec = get_content(extra)
+    if not isinstance(bc, list) or not isinstance(ec, list):
+        return
+    bc.extend(ec)
+
+
 def build_turns(messages: List[Dict[str, Any]]) -> List[Turn]:
     """
     Groups incremental transcript rows into turns:
@@ -493,7 +510,14 @@ def build_turns(messages: List[Dict[str, Any]]) -> List[Turn]:
             mid = get_message_id(msg) or f"noid:{len(assistant_order)}"
             if mid not in assistant_latest:
                 assistant_order.append(mid)
-            assistant_latest[mid] = msg
+                assistant_latest[mid] = msg
+            else:
+                # Claude Code splits ONE assistant message (same message.id) across
+                # multiple transcripts row: thinking/text first, then one row per
+                # parallel tool_use (rows can be interleaved with tool_result rows).
+                # "Latest row wins" dropped every parallel toll call but the last
+                # merge the content blocks instead so all tool_uses survive.
+                merge_assistant_content(assistant_latest[mid], msg)
             continue
 
         # ignore unknown rows


### PR DESCRIPTION
## Problem

When a turn fires several tools in **parallel** (e.g. 3 `WebFetch` calls at once or multiple subagents launched together via `Agent`), only the **last** tool span shows up in Langfuse. The rest silently vanish.

## Root cause

Claude Code writes one logical assistant message (single `message.id`) as **several**  transcript rows: the thinking/text rows first, then **one row per parallel** `tool_use` **block**, and these rows can be interleaved with `tool_result` rows. `build_turns()` de-dupes assistant rows by `message.id` with a "latest row wins" assignment:

```python
mid = get_message_id(msg) or f"noid:{len(assistant_order)}"
if mid not in assistant_latest:
    assistant_order.append(mid)
assistant_latest[mid] = msg  # overwrites; earlier tool_use rows are lost
```

So every parallel tool call but the last gets overwritten before emit.

## Raw transcript evidence
A real turn that fired 4 parallel `Read` calls. These are **4 separate JSONL rows** (distinct `uuid` + `timestamp`), but all share **one** `message.id` and each carries a single `tool_use` block (fields trimmed to the relevant ones):
```jsonl
// row 1
{
  "message": {
    "id": "msg_bdrk_…je4ivmq",
    "role": "assistant",
    "content": [
      {
        "type": "tool_use",
        "id": "toolu_…HV2",
        "name": "Read",
        "input": {
          "file_path": ".../subagent_one.md"
        }
      }
    ]
  },
  "uuid": "334452ca-…",
  "timestamp": "2026-06-19T08:42:41.885Z"
}

// row 2
{
  "message": {
    "id": "msg_bdrk_…je4ivmq",
    "role": "assistant",
    "content": [
      {
        "type": "tool_use",
        "id": "toolu_…8q4",
        "name": "Read",
        "input": {
          "file_path": ".../subagent_two.md"
        }
      }
    ]
  },
  "uuid": "d3cfa674-…",
  "timestamp": "2026-06-19T08:42:42.885Z"
}

// row 3
{
  "message": {
    "id": "msg_bdrk_…je4ivmq",
    "role": "assistant",
    "content": [
      {
        "type": "tool_use",
        "id": "toolu_…y4J",
        "name": "Read",
        "input": {
          "file_path": ".../subagent_three.md"
        }
      }
    ]
  },
  "uuid": "bd31bb32-…",
  "timestamp": "2026-06-19T08:42:42.921Z"
}

// row 4
{
  "message": {
    "id": "msg_bdrk_…je4ivmq",
    "role": "assistant",
    "content": [
      {
        "type": "tool_use",
        "id": "toolu_…PFY",
        "name": "Read",
        "input": {
          "file_path": ".../subagent_four.md"
        }
      }
    ]
  },
  "uuid": "7e37ddc2-…",
  "timestamp": "2026-06-19T08:42:43.139Z"
}
```
All four rows hash to the same key in `assistant_latest`, so the dict assignment keeps only row 4 (`subagent_four.md`) — rows 1–3 are silently overwritten and never emitted to Langfuse.

Note the rows aren't contiguous in the file either: `tool_result` rows for the earlier calls interleave between them, so a positional fix wouldn't be safe — merging by `message.id` is.

## Fix

Merge the content blocks across rows that share a `message.id` instead of overwriting, so all `tool_use` blocks survive.

Metadata (`model`, `usage`, `timestamp`) is identical across the split rows, so the first row's values are kept.

## Notes

- No behavior change for single-tool turns.
- Only affects turns traced after the fix; turns already recorded in `~/.claude/state/langfuse_state.json` are not rewritten.