### PR TITLE
fix: remove dead Claude hook payload fallbacks

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -195,21 +195,10 @@ def read_hook_payload() -> Dict[str, Any]:
         return {}
 
 def extract_session_and_transcript(payload: Dict[str, Any]) -> Tuple[Optional[str], Optional[Path]]:
-    """
-    Tries a few plausible field names; exact keys can vary across hook types/versions.
-    Prefer structured values from stdin over heuristics.
-    """
-    session_id = (
-        payload.get("sessionId")
-        or payload.get("session_id")
-        or payload.get("session", {}).get("id")
-    )
+    """Read the session id and transcript path from the hook payload."""
+    session_id = payload.get("session_id")
 
-    transcript = (
-        payload.get("transcriptPath")
-        or payload.get("transcript_path")
-        or payload.get("transcript", {}).get("path")
-    )
+    transcript = payload.get("transcript_path")
 
     if transcript:
         try:


### PR DESCRIPTION
## Summary

Cleans up the Claude Code hook payload parsing by removing fallback branches for payload shapes that are not used by real Claude Code hook events.

## Why

Real Stop and SessionEnd hook payloads use `session_id` and `transcript_path`. The previous camelCase and nested fallback branches made the parser look more permissive than it actually needed to be and added noise while debugging hook behavior.

This is part of LFE-10511.

## Changes

- Remove unused `sessionId` / `session.id` fallback for session extraction
- Remove unused `transcriptPath` / `transcript.path` fallback for transcript extraction
- Clarify the function docstring around the expected Claude Code payload shape

## Validation

- Verified against real Claude Code hook payloads
