### PR TITLE
fix(hook): trust the OS certificate store for TLS verification

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #   "langfuse>=4.0,<5",
+#   "truststore>=0.9",
 # ]
 # ///
 """
@@ -23,6 +24,18 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+
+# ----------------- OS trust store (fail-open) -----------------
+# Verify TLS against the operating system's certificate store instead of only
+# the bundled certifi CAs, so self-hosted Langfuse instances behind a locally
+# trusted CA (mkcert, corporate proxy) work without extra configuration.
+# Must run before any library creates an SSLContext.
+try:
+    import truststore
+
+    truststore.inject_into_ssl()
+except Exception:
+    pass
 
 # ----------------- Langfuse import (fail-open) -----------------
 try:


### PR DESCRIPTION
## Problem

Exporting traces to a **self-hosted Langfuse behind a locally trusted CA** (mkcert, internal/corporate CA) fails silently. Python trusts only the bundled certifi CAs — not the OS trust store where tools like `mkcert -install` register their root — so every OTLP export dies with `CERTIFICATE_VERIFY_FAILED` in the exporter's background thread. The hook still logs `Processed N turns`, so nothing hints at the failure; traces just never appear.

Environment-variable workarounds don't reach the hook either: Claude Code does not pass `OTEL_*` variables from `settings.json` `env` to subprocesses ([documented here](https://code.claude.com/docs/en/monitoring-usage)), and `REQUESTS_CA_BUNDLE` requires every user to maintain a combined CA bundle by hand.

## Fix

Inject [truststore](https://github.com/sethmlarson/truststore) — the library pip and uv use for exactly this — at script start, before any SSL context is created. TLS verification then delegates to the OS trust store (Keychain on macOS, CA store on Windows, OpenSSL dirs on Linux), so locally trusted CAs work with zero configuration.

- Fail-open: if truststore is missing (e.g. the plain `python3` fallback without the PEP 723 deps), the hook behaves exactly as today.
- No behavior change for Langfuse Cloud users — public CAs are in every OS store.
- `truststore>=0.9` supports Python 3.10+, matching the script's `requires-python`.

## Testing

Against a self-hosted instance at `https://langfuse.localhost.dev` with an mkcert certificate (macOS):

- Fresh venv without truststore: `requests.get(...)` → `SSLError(CERTIFICATE_VERIFY_FAILED)`
- Same venv after `truststore.inject_into_ssl()`: `200`, and the OTLP exporter reaches the server
- Interpreter without truststore installed: import fails open, hook runs unchanged