### PR TITLE
fix(hook): persist open turns across Stop firings

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -2066,53 +2066,106 @@ def post_ingestion_events(config: LangfuseConfig, events: List[Dict[str, Any]]) 
         info(f"ingestion update failed ({len(events)} event(s)): {type(e).__name__}: {e}")
 
 
-def observe_turn(langfuse: Langfuse, trace_span: Any, turn: Turn,
-                 subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]]) -> Optional[datetime]:
-    """Emit the turn's generations and tool observations under its root span."""
-    return emit_turn_observations(
-        langfuse,
-        trace_span._otel_span,
-        turn,
-        parse_timestamp(turn.user_msg),
-        subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
-    )
-
-
-def close_turn_root_span(trace_span: Any, turn: Turn, obs_end_ts: Optional[datetime]) -> None:
-    """Close the turn's root span with its final output and end time."""
+def build_turn_output_payload(turn: Turn) -> Dict[str, Any]:
     last_assistant = turn.assistant_msgs[-1]
-    final_assistant_text, _ = truncate_text(extract_text_from_content(get_content_from_row(last_assistant)))
-    trace_span.update(output={"role": "assistant", "content": final_assistant_text})
-    end_ts = _get_latest_timestamp(
+    text, _ = truncate_text(extract_text_from_content(get_content_from_row(last_assistant)))
+    return {"role": "assistant", "content": text}
+
+
+def get_root_span_end_time(turn: Turn, obs_end_ts: Optional[datetime]) -> Optional[datetime]:
+    return _get_latest_timestamp(
         get_turn_end_timestamp(turn),
-        parse_timestamp(last_assistant),
+        parse_timestamp(turn.assistant_msgs[-1]),
         obs_end_ts,
         parse_timestamp(turn.user_msg),
     )
-    trace_span.end(end_time=to_otel_nanoseconds(end_ts))
 
 
-def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, transcript_path: Path,
+def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
+              turn: Turn, transcript_path: Path,
+              update_sink: List[Dict[str, Any]],
               user_id: Optional[str] = None,
-              subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
+              subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
+              progress: Optional[Dict[str, Any]] = None,
+              close: bool = True) -> Dict[str, Any]:
+    """Emit a turn, resuming from prior firings' progress.
+
+    With no progress and close=True this is the classic one-shot emission.
+    With close=False only ready observations ship (those whose emitted form
+    can no longer change) and the root span is ended provisionally; a later
+    firing resumes from the returned progress (root span id + emitted keys)
+    and corrects the root via span-update.
+    """
+    progress = dict(progress or {})
+    cursor = EmissionCursor(
+        emitted=set(k for k in (progress.get("emitted_keys") or []) if isinstance(k, str)),
+        completed_only=not close,
+    )
     with propagate_attributes(
         session_id=session_id,
         user_id=user_id,
         trace_name=trace_display_name(session_id, turn_num),
         tags=get_trace_tags(turn),
     ):
-        trace_span = open_turn_root_span(langfuse, session_id, turn_num, turn, transcript_path)
-        obs_end_ts = observe_turn(langfuse, trace_span, turn, subagent_transcripts_by_tool_use_id)
-        close_turn_root_span(trace_span, turn, obs_end_ts)
+        trace_span = None
+        root_span_id = progress.get("root_span_id")
+        if not is_valid_span_id_hex(root_span_id):
+            trace_span = open_turn_root_span(langfuse, session_id, turn_num, turn, transcript_path)
+            root_span_id = getattr(trace_span, "id", None)
+            progress["root_span_id"] = root_span_id
+            progress["trace_id"] = getattr(trace_span, "trace_id", None)
+            parent_otel_span = trace_span._otel_span
+        else:
+            # Root span exported by an earlier firing: attach children to it
+            # via a carrier and correct the root itself via span-update.
+            parent_otel_span = remote_parent(
+                langfuse, session_id, turn.user_msg.get("uuid"), root_span_id=root_span_id
+            )
+        obs_end_ts = emit_turn_observations(
+            langfuse,
+            parent_otel_span,
+            turn,
+            parse_timestamp(turn.user_msg),
+            subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+            cursor=cursor,
+        )
+        end_ts = get_root_span_end_time(turn, obs_end_ts)
+        output = build_turn_output_payload(turn)
+        if trace_span is not None:
+            # OTel only exports ended spans, so the root closes now either
+            # way; a non-closing turn gets its final output/end via a later
+            # firing's span-update.
+            trace_span.update(output=output)
+            trace_span.end(end_time=to_otel_nanoseconds(end_ts))
+        elif close or cursor.newly_emitted:
+            # Idle firings send no root update: every update creates a row
+            # version on the server, visible as a transient duplicate root
+            # in the events view until ClickHouse merges the versions.
+            user_text, user_text_meta = truncate_text(
+                extract_text_from_content(get_content_from_row(turn.user_msg))
+            )
+            queue_root_span_update(
+                update_sink, progress.get("trace_id"), root_span_id,
+                start_time=parse_timestamp(turn.user_msg),
+                end_time=end_ts,
+                input_payload={"role": "user", "content": user_text},
+                output=output,
+                metadata=build_trace_metadata(
+                    session_id, turn_num, turn, transcript_path, user_text_meta
+                ),
+            )
+    progress["emitted_keys"] = sorted(cursor.emitted)
+    return progress
 
 
 # ---- New turn emission orchestration ----
-def emit_ready_turns(
+def emit_and_close_ready_turns(
     langfuse: Langfuse,
     session_id: str,
     transcript_path: Path,
     turns_to_emit: List[Turn],
     session_state: SessionState,
+    update_sink: List[Dict[str, Any]],
     *,
     user_id: Optional[str],
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
@@ -2137,14 +2190,18 @@ def emit_ready_turns(
                 turn_num,
                 turn,
                 transcript_path,
+                update_sink,
                 user_id=user_id,
                 subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+                progress=None,
+                close=True,
             )
         except Exception as e:
             # Log at INFO so SDK incompatibilities (and other emit failures)
             # are visible without needing CC_LANGFUSE_DEBUG=true.
             info(f"emit_turn failed: {type(e).__name__}: {e}")
     return emitted
+
 
 def emit_new_turns_from_transcript(
     langfuse: Langfuse,
@@ -2154,6 +2211,9 @@ def emit_new_turns_from_transcript(
     *,
     flush_deferred_agent_turns: bool = False,
 ) -> int:
+    # Ingestion updates are only collected while the lock is held and POSTed
+    # afterwards: network latency must never block concurrent hook runs.
+    update_sink: List[Dict[str, Any]] = []
     with FileLock(LOCK_FILE):
         state = load_hook_state()
         key = get_session_state_key(session_id, str(transcript_path))
@@ -2178,19 +2238,22 @@ def emit_new_turns_from_transcript(
             session_state,
             flush_deferred_agent_turns=flush_deferred_agent_turns,
         )
-        emitted = emit_ready_turns(
+        emitted = emit_and_close_ready_turns(
             langfuse,
             session_id,
             transcript_path,
             turns_to_emit,
             session_state,
+            update_sink,
             user_id=config.user_id,
             subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
         )
 
         session_state.turn_count += emitted
         save_session_state(state, key, session_state)
-        return emitted
+
+    post_ingestion_events(config, update_sink)
+    return emitted
 
 
 def flush_and_shutdown_langfuse_client(langfuse: Optional[Langfuse]) -> None:

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1921,25 +1921,43 @@ def build_trace_metadata(
             trace_metadata[dst_key] = value
     return trace_metadata
 
-def deterministic_trace_parent(langfuse: Langfuse, session_id: str, turn: Turn) -> Optional[Any]:
+def is_valid_span_id_hex(span_id: Any) -> bool:
+    return (
+        isinstance(span_id, str)
+        and len(span_id) == 16
+        and all(c in "0123456789abcdef" for c in span_id)
+    )
+
+
+def remote_parent(langfuse: Langfuse, session_id: str, user_row_uuid: Any,
+                  root_span_id: Optional[str] = None) -> Optional[Any]:
     """Return a carrier span pinning the turn's trace id, seeded from session
-    id + the turn's user-row uuid."""
-    user_row_uuid = turn.user_msg.get("uuid")
+    id + the turn's user-row uuid.
+
+    Without root_span_id the carrier gets a phantom span id: it is never
+    exported, OTel merely requires a valid non-zero id, and children become
+    the trace's roots. With root_span_id (the 16-hex observation id of a
+    root span opened by an earlier firing) children nest under that span
+    instead, so continuation firings can extend an already-emitted turn.
+    """
     if not isinstance(user_row_uuid, str) or not user_row_uuid:
         return None
+    if root_span_id is not None and not is_valid_span_id_hex(root_span_id):
+        # A corrupt stored span id must not cost the deterministic trace id:
+        # degrade to the phantom-parent path instead of the except fallback.
+        debug(f"remote_parent: ignoring malformed root_span_id {root_span_id!r}")
+        root_span_id = None
     try:
         trace_id = langfuse.create_trace_id(seed=f"{session_id}:{user_row_uuid}")
         parent_context = otel_trace_api.SpanContext(
             trace_id=int(trace_id, 16),
-            # The carrier is never exported; OTel merely requires a valid
-            # non-zero span id here.
-            span_id=random.getrandbits(64) or 1,
+            span_id=int(root_span_id, 16) if root_span_id else (random.getrandbits(64) or 1),
             trace_flags=otel_trace_api.TraceFlags(0x01),  # sampled
             is_remote=False,
         )
         return otel_trace_api.NonRecordingSpan(parent_context)
     except Exception as e:
-        debug(f"deterministic_trace_parent failed, falling back to random trace id: {e}")
+        debug(f"remote_parent failed, falling back to random trace id: {e}")
         return None
 
 
@@ -1959,7 +1977,7 @@ def open_turn_root_span(langfuse: Langfuse, session_id: str, turn_num: int, turn
         name="Conversational Turn",
         as_type="span",
         start_time=parse_timestamp(turn.user_msg),
-        parent_otel_span=deterministic_trace_parent(langfuse, session_id, turn),
+        parent_otel_span=remote_parent(langfuse, session_id, turn.user_msg.get("uuid")),
         as_root=True,
         input={"role": "user", "content": user_text},
         metadata=trace_metadata,

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -271,6 +271,10 @@ class SessionState:
     # Task-notification rows whose tool_use_id could not be resolved yet
     # (task-id-only and the subagent meta.json not on disk); retried each run.
     pending_task_notifications: List[Dict[str, Any]] = field(default_factory=list)
+    # Rows of the trailing turn of the last batch. Stop fires multiple times
+    # within one logical turn (task notifications, blocking hooks), so the
+    # trailing turn stays open until a new user row or SessionEnd closes it.
+    open_turn_rows: List[Dict[str, Any]] = field(default_factory=list)
 
 def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     s = global_state.get(key, {})
@@ -280,12 +284,16 @@ def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     pending_task_notifications = s.get("pending_task_notifications")
     if not isinstance(pending_task_notifications, list):
         pending_task_notifications = []
+    open_turn_rows = s.get("open_turn_rows")
+    if not isinstance(open_turn_rows, list):
+        open_turn_rows = []
     return SessionState(
         offset=int(s.get("offset", 0)),
         buffer=str(s.get("buffer", "")),
         turn_count=int(s.get("turn_count", 0)),
         pending_agent_turns=pending_agent_turns,
         pending_task_notifications=pending_task_notifications,
+        open_turn_rows=open_turn_rows,
     )
 
 def update_session_state(global_state: Dict[str, Any], key: str, session_state: SessionState) -> None:
@@ -295,6 +303,7 @@ def update_session_state(global_state: Dict[str, Any], key: str, session_state: 
         "turn_count": session_state.turn_count,
         "pending_agent_turns": session_state.pending_agent_turns or [],
         "pending_task_notifications": session_state.pending_task_notifications or [],
+        "open_turn_rows": session_state.open_turn_rows or [],
         "updated": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -611,15 +620,15 @@ def resolve_deferred_agent_turns(
             pending_turn.setdefault("resolved_tool_use_ids", []).append(tool_use_id)
 
     # Retry stashed notifications from earlier runs first (they are older than
-    # anything in the batch); their task-id may resolve now.
+    # anything in the batch); their task-id may resolve now. Entries matching
+    # no deferred turn stay stashed: their owning turn may still be open and
+    # only defer once a new user row closes it. Leftovers are cleared at
+    # session end and the stash is size-capped.
     for row in session_state.pending_task_notifications:
         tool_use_id = get_tool_use_id_for_task_notification(row, task_id_to_tool_use_id)
-        if tool_use_id is None:
-            stashed_notifications.append(row)
-            continue
-        pending_turn = _find_pending_agent_turn(session_state, tool_use_id)
+        pending_turn = _find_pending_agent_turn(session_state, tool_use_id) if tool_use_id else None
         if pending_turn is None:
-            debug(f"Dropping stashed task notification for {tool_use_id}: no deferred turn waits for it")
+            stashed_notifications.append(row)
             continue
         route_to_pending_turn(pending_turn, row, tool_use_id)
 
@@ -787,27 +796,41 @@ def add_task_notification_row(
     row: Dict[str, Any],
     state: TurnAssemblyState,
     task_id_to_tool_use_id: Optional[Dict[str, str]] = None,
+    closed_turns: Optional[List[Turn]] = None,
 ) -> bool:
     if not is_task_notification_row(row):
         return False
 
-    if state.current_turn_user_row is None:
-        return True
-
     tool_use_id = get_tool_use_id_for_task_notification(row, task_id_to_tool_use_id)
     if not tool_use_id:
-        state.current_rows.append(row)
+        if state.current_turn_user_row is not None:
+            state.current_rows.append(row)
         return True
 
-    existing_result = state.tool_results_by_id.get(tool_use_id)
-    if isinstance(existing_result, dict):
-        existing_result["final_content"] = get_result_from_task_notification(row)
-        existing_result["final_timestamp"] = row.get("timestamp")
-    else:
-        state.tool_results_by_id[tool_use_id] = {
-            "content": get_result_from_task_notification(row),
-            "timestamp": row.get("timestamp"),
-        }
+    if state.current_turn_user_row is not None:
+        existing_result = state.tool_results_by_id.get(tool_use_id)
+        if isinstance(existing_result, dict):
+            existing_result["final_content"] = get_result_from_task_notification(row)
+            existing_result["final_timestamp"] = row.get("timestamp")
+            state.current_rows.append(row)
+            return True
+
+    # The launching turn may have been closed earlier in this same batch (a
+    # new user row arrived before the notification did).
+    for closed_turn in reversed(closed_turns or []):
+        closed_result = closed_turn.tool_results_by_id.get(tool_use_id)
+        if isinstance(closed_result, dict):
+            closed_result["final_content"] = get_result_from_task_notification(row)
+            closed_result["final_timestamp"] = row.get("timestamp")
+            closed_turn.rows.append(row)
+            return True
+
+    if state.current_turn_user_row is None:
+        return True
+    state.tool_results_by_id[tool_use_id] = {
+        "content": get_result_from_task_notification(row),
+        "timestamp": row.get("timestamp"),
+    }
     state.current_rows.append(row)
     return True
 
@@ -891,16 +914,21 @@ def add_assistant_row(row: Dict[str, Any], state: TurnAssemblyState) -> None:
     state.current_rows.append(row)
 
 
-def build_turns(
+def assemble_turns(
     rows: List[Dict[str, Any]],
     task_id_to_tool_use_id: Optional[Dict[str, str]] = None,
-) -> List[Turn]:
+) -> Tuple[List[Turn], Optional[Turn], List[Dict[str, Any]]]:
     """
     Groups incremental transcript rows into turns:
     user (non-tool-result) -> assistant messages -> (tool_result rows, possibly interleaved)
     Uses:
     - assistant rows merged by message.id (all content blocks concatenated)
     - tool results dedupe by tool_use_id (latest wins)
+
+    Returns (closed_turns, trailing_turn, trailing_turn_rows). The trailing
+    turn is the one still open at the end of the rows: only a following user
+    row proves a turn is complete, so incremental callers keep its raw rows
+    and re-attach them to the next batch instead of emitting it right away.
     """
     turns: List[Turn] = []
     state = TurnAssemblyState()
@@ -912,7 +940,7 @@ def build_turns(
         if add_tool_result_row(row, state):
             continue
 
-        if add_task_notification_row(row, state, task_id_to_tool_use_id):
+        if add_task_notification_row(row, state, task_id_to_tool_use_id, closed_turns=turns):
             continue
 
         role = get_user_or_assistant_role_from_row(row)
@@ -931,9 +959,19 @@ def build_turns(
 
         # ignore unknown rows
 
-    turn = build_turn_from_state(state)
-    if turn is not None:
-        turns.append(turn)
+    trailing_turn = build_turn_from_state(state)
+    trailing_turn_rows = list(state.current_rows) if state.current_turn_user_row is not None else []
+    return turns, trailing_turn, trailing_turn_rows
+
+
+def build_turns(
+    rows: List[Dict[str, Any]],
+    task_id_to_tool_use_id: Optional[Dict[str, str]] = None,
+) -> List[Turn]:
+    """Group a complete row list into turns, including the trailing one."""
+    turns, trailing_turn, _ = assemble_turns(rows, task_id_to_tool_use_id)
+    if trailing_turn is not None:
+        turns.append(trailing_turn)
     return turns
 
 
@@ -947,6 +985,15 @@ def get_new_turns_from_transcript(
     rows, session_state = read_new_jsonl(transcript_path, session_state)
     task_id_to_tool_use_id = get_task_id_to_tool_use_id(subagent_transcripts_by_tool_use_id)
 
+    # Re-attach the trailing open turn from the previous run. Stop fires
+    # multiple times within one logical turn, so a batch can begin with
+    # user-less continuation rows (task notifications, assistant rows); with
+    # the open turn's rows in front they attach to it instead of being
+    # dropped by turn assembly.
+    if session_state.open_turn_rows:
+        rows = session_state.open_turn_rows + rows
+        session_state.open_turn_rows = []
+
     deferred_turn_row_lists, rows = resolve_deferred_agent_turns(rows, session_state, task_id_to_tool_use_id)
 
     if flush_deferred_agent_turns and session_state.pending_agent_turns:
@@ -956,7 +1003,11 @@ def get_new_turns_from_transcript(
             deferred_turn_row_lists = deferred_turn_row_lists + flushed_row_lists
 
     if flush_deferred_agent_turns and session_state.pending_task_notifications:
-        debug(f"Dropping {len(session_state.pending_task_notifications)} unresolved task notification(s) at session end")
+        # Last chance: appended to the row stream, a stashed notification can
+        # still attach to the (reattached) open turn or a turn closed in this
+        # batch; anything unmatched is discarded with the session.
+        debug(f"Replaying {len(session_state.pending_task_notifications)} stashed task notification(s) at session end")
+        rows = rows + session_state.pending_task_notifications
         session_state.pending_task_notifications = []
 
     # Each deferred row list is a complete turn from an earlier hook run, so
@@ -965,8 +1016,18 @@ def get_new_turns_from_transcript(
     turns: List[Turn] = []
     for deferred_turn_rows in deferred_turn_row_lists:
         turns.extend(build_turns(deferred_turn_rows, task_id_to_tool_use_id))
-    if rows:
-        turns.extend(build_turns(rows, task_id_to_tool_use_id))
+
+    batch_turns, trailing_turn, trailing_turn_rows = assemble_turns(rows, task_id_to_tool_use_id)
+    turns.extend(batch_turns)
+
+    if flush_deferred_agent_turns:
+        # SessionEnd: nothing can continue the trailing turn anymore.
+        if trailing_turn is not None:
+            turns.append(trailing_turn)
+    else:
+        session_state.open_turn_rows = trailing_turn_rows
+        if trailing_turn_rows:
+            debug(f"Holding trailing open turn ({len(trailing_turn_rows)} row(s)) until a new user row closes it")
 
     return turns, session_state
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1345,6 +1345,40 @@ def build_tool_metadata(
         })
     return tool_metadata
 
+@dataclass
+class EmissionCursor:
+    """Tracks which of a turn's observations were already emitted (namespaced
+    keys: gen:/tool:/subagent:) so continuation firings only emit what is new.
+
+    completed_only skips observations whose emitted form could still change
+    (generation awaiting tool results, running async subagent); at turn close
+    the cursor runs with completed_only=False so everything remaining ships.
+    """
+    emitted: set
+    completed_only: bool = False
+    newly_emitted: List[str] = field(default_factory=list)
+
+    def should_emit(self, key: str, complete: bool = True) -> bool:
+        if key in self.emitted:
+            return False
+        if self.completed_only and not complete:
+            return False
+        self.emitted.add(key)
+        self.newly_emitted.append(key)
+        return True
+
+
+def fresh_cursor() -> EmissionCursor:
+    """Cursor for one-shot emission: nothing emitted yet, emit everything."""
+    return EmissionCursor(emitted=set(), completed_only=False)
+
+
+def generation_emission_key(assistant_index: int, assistant_message: Dict[str, Any]) -> str:
+    # message.id is the merge unit of assistant rows; the noid fallback is
+    # stable because turns are always rebuilt in transcript order.
+    return f"gen:{get_message_id(assistant_message) or f'noid:{assistant_index}'}"
+
+
 def emit_single_tool_observation(
     langfuse: Langfuse,
     parent_otel_span: Any,
@@ -1354,6 +1388,8 @@ def emit_single_tool_observation(
     subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]],
     pending_subagents: List[Dict[str, Any]],
     pending_async_tool_results: List[Dict[str, Any]],
+    cursor: EmissionCursor,
+    tool_key: str,
 ) -> EmittedSingleToolObservation:
     tool_use_id = str(tool_use.get("id") or "")
     tool_name = tool_use.get("name") or "unknown"
@@ -1377,16 +1413,20 @@ def emit_single_tool_observation(
     tool_metadata = build_tool_metadata(tool_name, tool_use_id, tool_input_meta, tool_result, subagent)
 
     tool_use_timestamp = parse_timestamp(turn.tool_use_timestamps_by_id.get(tool_use_id)) or assistant_timestamp
-    tool_span = _start_backdated(
-        langfuse,
-        name=f"Tool: {tool_name}",
-        as_type="tool",
-        start_time=tool_use_timestamp,
-        parent_otel_span=parent_otel_span,
-        input=tool_input,
-        metadata=tool_metadata,
-    )
-    tool_span.update(output=tool_output)
+    # A tool span's end time comes from its result row, so it only counts as
+    # complete once that row exists.
+    tool_span = None
+    if cursor.should_emit(tool_key, complete=tool_result_entry is not None):
+        tool_span = _start_backdated(
+            langfuse,
+            name=f"Tool: {tool_name}",
+            as_type="tool",
+            start_time=tool_use_timestamp,
+            parent_otel_span=parent_otel_span,
+            input=tool_input,
+            metadata=tool_metadata,
+        )
+        tool_span.update(output=tool_output)
 
     subagent_end_timestamp = None
     if subagent:
@@ -1398,12 +1438,24 @@ def emit_single_tool_observation(
                 "ready_timestamp": tool_result.final_result_timestamp,
             })
         else:
-            subagent_end_timestamp = emit_subagent_observations(
-                langfuse,
-                parent_otel_span,
-                subagent,
-                tool_use_timestamp,
+            # Without a final result the subagent may still be running: its
+            # transcript on disk is not authoritative yet. No tool_result row
+            # at all means the tool (sync agents included) is still executing,
+            # so completeness must fail closed like the neighboring gates.
+            subagent_still_running = tool_result_entry is None or (
+                is_async_agent_launch_result(tool_result_entry)
+                and (
+                    not isinstance(tool_result_entry, dict)
+                    or tool_result_entry.get("final_content") is None
+                )
             )
+            if cursor.should_emit(f"subagent:{tool_use_id or tool_key}", complete=not subagent_still_running):
+                subagent_end_timestamp = emit_subagent_observations(
+                    langfuse,
+                    parent_otel_span,
+                    subagent,
+                    tool_use_timestamp,
+                )
 
     tool_end_timestamp = _get_latest_timestamp(tool_result.result_timestamp, tool_use_timestamp)
     handoff_timestamp = (
@@ -1412,7 +1464,8 @@ def emit_single_tool_observation(
         or subagent_end_timestamp
         or assistant_timestamp
     )
-    tool_span.end(end_time=to_otel_nanoseconds(tool_end_timestamp))
+    if tool_span is not None:
+        tool_span.end(end_time=to_otel_nanoseconds(tool_end_timestamp))
 
     if tool_result.final_result_timestamp is not None and tool_result.final_output is not None:
         pending_async_tool_results.append({
@@ -1439,17 +1492,22 @@ def emit_tool_observation_batch(
     parent_otel_span: Any,
     turn: Turn,
     assistant_message: Dict[str, Any],
+    assistant_index: int,
     tool_uses: List[Dict[str, Any]],
     subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]],
     pending_subagents: List[Dict[str, Any]],
     pending_async_tool_results: List[Dict[str, Any]],
+    cursor: EmissionCursor,
 ) -> EmittedToolObservationBatch:
     assistant_timestamp = parse_timestamp(assistant_message)
+    generation_key = generation_emission_key(assistant_index, assistant_message)
     tool_result_timestamps: List[datetime] = []
     emitted_tool_results: List[Dict[str, Any]] = []
     latest_tool_end_timestamp: Optional[datetime] = None
 
-    for tool_use in tool_uses:
+    for tool_index, tool_use in enumerate(tool_uses):
+        tool_use_id = str(tool_use.get("id") or "")
+        tool_key = f"tool:{tool_use_id}" if tool_use_id else f"tool:{generation_key}:{tool_index}"
         emitted_tool = emit_single_tool_observation(
             langfuse,
             parent_otel_span,
@@ -1459,6 +1517,8 @@ def emit_tool_observation_batch(
             subagent_transcripts_by_tool_use_id,
             pending_subagents,
             pending_async_tool_results,
+            cursor,
+            tool_key,
         )
         if emitted_tool.handoff_timestamp is not None:
             tool_result_timestamps.append(emitted_tool.handoff_timestamp)
@@ -1588,14 +1648,38 @@ def emit_generation_observation(
 def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn,
                            start_timestamp: Optional[datetime],
                            generation_prefix: str = "LLM Call",
-                           subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None) -> Optional[datetime]:
-    """Emit a turn's generations and tool observations under an existing span."""
+                           subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
+                           cursor: Optional[EmissionCursor] = None) -> Optional[datetime]:
+    """Emit a turn's generations and tool observations under an existing span.
+
+    The full turn is always walked so cross-observation context (generation
+    inputs from previous tool results, timestamps) stays correct; the cursor
+    only gates which spans are actually created. Without a cursor everything
+    is emitted (one-shot behavior).
+    """
+    cursor = cursor if cursor is not None else fresh_cursor()
     user_text, _ = truncate_text(extract_text_from_content(get_content_from_row(turn.user_msg)))
     previous_timestamp = start_timestamp
     previous_tool_results: List[Dict[str, Any]] = []
     pending_async_tool_results: List[Dict[str, Any]] = []
     pending_subagents: List[Dict[str, Any]] = []
     latest_end_timestamp = start_timestamp
+    # True once the walk passed an async launch whose final result is still
+    # missing; later generations' inputs can then still change retroactively.
+    unresolved_async_launch_seen = False
+
+    def emit_pending_subagent(pending_subagent: Dict[str, Any]) -> None:
+        nonlocal latest_end_timestamp
+        subagent_key = f"subagent:{pending_subagent.get('tool_use_id')}"
+        if not cursor.should_emit(subagent_key, complete=True):
+            return
+        subagent_end_timestamp = emit_subagent_observations(
+            langfuse,
+            parent_otel_span,
+            pending_subagent["subagent"],
+            pending_subagent.get("display_start_timestamp") or pending_subagent.get("start_timestamp"),
+        )
+        latest_end_timestamp = _get_latest_timestamp(latest_end_timestamp, subagent_end_timestamp)
 
     for assistant_index, assistant_message in enumerate(turn.assistant_msgs):
         assistant_timestamp = parse_timestamp(assistant_message)
@@ -1605,13 +1689,7 @@ def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn
                 assistant_timestamp,
             )
             for ready_subagent in ready_subagents:
-                subagent_end_timestamp = emit_subagent_observations(
-                    langfuse,
-                    parent_otel_span,
-                    ready_subagent["subagent"],
-                    ready_subagent.get("display_start_timestamp") or ready_subagent.get("start_timestamp"),
-                )
-                latest_end_timestamp = _get_latest_timestamp(latest_end_timestamp, subagent_end_timestamp)
+                emit_pending_subagent(ready_subagent)
 
         ready_async_tool_results: List[Dict[str, Any]] = []
         if assistant_index > 0 and pending_async_tool_results:
@@ -1628,14 +1706,33 @@ def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn
             ready_async_tool_results,
         )
         generation_start_timestamp = previous_timestamp or assistant_timestamp
-        generation_span = emit_generation_observation(
-            langfuse,
-            parent_otel_span=parent_otel_span,
-            generation_prefix=generation_prefix,
-            assistant_index=assistant_index,
-            start_timestamp=generation_start_timestamp,
-            generation_kwargs=generation_kwargs,
+        # A generation is only complete when its emitted form cannot change
+        # anymore: (a) every tool_use of this message has its result (end
+        # time), (b) no earlier async launch is unresolved (a late
+        # notification would retroactively join this generation's input).
+        # The trailing message needs no extra guard: Stop only fires after a
+        # response is fully written, and no message.id ever grows across a
+        # Stop boundary (0 cases across all local transcripts).
+        generation_complete = (
+            not unresolved_async_launch_seen
+            and all(
+                str(tool_use.get("id") or "") in turn.tool_results_by_id
+                for tool_use in tool_uses
+            )
         )
+        generation_span = None
+        if cursor.should_emit(
+            generation_emission_key(assistant_index, assistant_message),
+            complete=generation_complete,
+        ):
+            generation_span = emit_generation_observation(
+                langfuse,
+                parent_otel_span=parent_otel_span,
+                generation_prefix=generation_prefix,
+                assistant_index=assistant_index,
+                start_timestamp=generation_start_timestamp,
+                generation_kwargs=generation_kwargs,
+            )
         update_pending_subagent_display_start_after_launch_response(
             pending_subagents,
             previous_tool_results,
@@ -1647,10 +1744,12 @@ def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn
             parent_otel_span,
             turn,
             assistant_message,
+            assistant_index,
             tool_uses,
             subagent_transcripts_by_tool_use_id,
             pending_subagents,
             pending_async_tool_results,
+            cursor,
         )
         latest_end_timestamp = _get_latest_timestamp(
             latest_end_timestamp,
@@ -1662,12 +1761,20 @@ def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn
             if emitted_tools.result_timestamps
             else assistant_timestamp
         )
-        generation_span.end(
-            end_time=to_otel_nanoseconds(
-                generation_end_timestamp or assistant_timestamp or previous_timestamp
+        if generation_span is not None:
+            generation_span.end(
+                end_time=to_otel_nanoseconds(
+                    generation_end_timestamp or assistant_timestamp or previous_timestamp
+                )
             )
-        )
         latest_end_timestamp = _get_latest_timestamp(latest_end_timestamp, generation_end_timestamp)
+
+        for tool_use in tool_uses:
+            entry = turn.tool_results_by_id.get(str(tool_use.get("id") or ""))
+            if is_async_agent_launch_result(entry) and (
+                not isinstance(entry, dict) or entry.get("final_content") is None
+            ):
+                unresolved_async_launch_seen = True
 
         previous_tool_results = emitted_tools.tool_results
         if emitted_tools.result_timestamps:
@@ -1676,13 +1783,7 @@ def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn
             previous_timestamp = assistant_timestamp
 
     for pending_subagent in pending_subagents:
-        subagent_end_timestamp = emit_subagent_observations(
-            langfuse,
-            parent_otel_span,
-            pending_subagent["subagent"],
-            pending_subagent.get("display_start_timestamp") or pending_subagent.get("start_timestamp"),
-        )
-        latest_end_timestamp = _get_latest_timestamp(latest_end_timestamp, subagent_end_timestamp)
+        emit_pending_subagent(pending_subagent)
 
     return latest_end_timestamp
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -13,6 +13,7 @@ Claude Code -> Langfuse hook
 import json
 import logging
 import os
+import random
 import sys
 import threading
 import time
@@ -1752,6 +1753,28 @@ def build_trace_metadata(
             trace_metadata[dst_key] = value
     return trace_metadata
 
+def deterministic_trace_parent(langfuse: Langfuse, session_id: str, turn: Turn) -> Optional[Any]:
+    """Return a carrier span pinning the turn's trace id, seeded from session
+    id + the turn's user-row uuid."""
+    user_row_uuid = turn.user_msg.get("uuid")
+    if not isinstance(user_row_uuid, str) or not user_row_uuid:
+        return None
+    try:
+        trace_id = langfuse.create_trace_id(seed=f"{session_id}:{user_row_uuid}")
+        parent_context = otel_trace_api.SpanContext(
+            trace_id=int(trace_id, 16),
+            # The carrier is never exported; OTel merely requires a valid
+            # non-zero span id here.
+            span_id=random.getrandbits(64) or 1,
+            trace_flags=otel_trace_api.TraceFlags(0x01),  # sampled
+            is_remote=False,
+        )
+        return otel_trace_api.NonRecordingSpan(parent_context)
+    except Exception as e:
+        debug(f"deterministic_trace_parent failed, falling back to random trace id: {e}")
+        return None
+
+
 def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, transcript_path: Path,
               user_id: Optional[str] = None,
               subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
@@ -1781,6 +1804,7 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
             name=root_observation_name,
             as_type="span",
             start_time=user_ts,
+            parent_otel_span=deterministic_trace_parent(langfuse, session_id, turn),
             input={"role": "user", "content": user_text},
             metadata=trace_metadata,
         )

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -10,6 +10,7 @@ Claude Code -> Langfuse hook
 
 """
 
+import base64
 import json
 import logging
 import os
@@ -18,6 +19,8 @@ import sys
 import threading
 import time
 import hashlib
+import urllib.request
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
@@ -1989,6 +1992,78 @@ def open_turn_root_span(langfuse: Langfuse, session_id: str, turn_num: int, turn
         input={"role": "user", "content": user_text},
         metadata=trace_metadata,
     )
+
+
+def queue_root_span_update(update_sink: List[Dict[str, Any]], trace_id: Any, root_span_id: Any,
+                           *, start_time: Optional[datetime] = None,
+                           end_time: Optional[datetime] = None,
+                           input_payload: Any = None, output: Any = None,
+                           metadata: Optional[Dict[str, Any]] = None) -> None:
+    """Queue span-update (+ trace output upsert) events for a provisionally
+    exported root span. Events are sent AFTER the state lock is released
+    (post_ingestion_events) so network latency never blocks other hook runs.
+
+    Callers pass the FULL root payload (name/startTime/input/metadata, not
+    just the changed output/endTime): the ingestion worker may process an
+    update before the original row is queryable, making the update version a
+    standalone row — and whichever version survives the ClickHouse merge
+    must have no holes.
+    """
+    if not is_valid_span_id_hex(root_span_id) or not isinstance(trace_id, str) or not trace_id:
+        return
+    body: Dict[str, Any] = {"id": root_span_id, "traceId": trace_id, "name": "Conversational Turn"}
+    if start_time is not None:
+        body["startTime"] = start_time.isoformat()
+    if input_payload is not None:
+        body["input"] = input_payload
+    if end_time is not None:
+        body["endTime"] = end_time.isoformat()
+    if output is not None:
+        body["output"] = output
+    if metadata is not None:
+        body["metadata"] = metadata
+    now_iso = datetime.now(timezone.utc).isoformat()
+    update_sink.append({
+        "id": str(uuid.uuid4()),
+        "timestamp": now_iso,
+        "type": "span-update",
+        "body": body,
+    })
+    if output is not None:
+        # The trace record derives input/output from the as_root span only at
+        # export time; a later span-update does not refresh it. Upsert the
+        # trace output explicitly so the dashboard header follows.
+        update_sink.append({
+            "id": str(uuid.uuid4()),
+            "timestamp": now_iso,
+            "type": "trace-create",
+            "body": {"id": trace_id, "output": output},
+        })
+
+
+def post_ingestion_events(config: LangfuseConfig, events: List[Dict[str, Any]]) -> None:
+    """Best-effort single POST to the batch ingestion API (fail-open).
+
+    The server upserts by id; it answers 207 even when individual events
+    fail, so the error list is logged explicitly (spike-v2 lesson).
+    """
+    if not events:
+        return
+    try:
+        payload = json.dumps({"batch": events}).encode("utf-8")
+        request = urllib.request.Request(
+            config.host.rstrip("/") + "/api/public/ingestion", data=payload, method="POST"
+        )
+        token = base64.b64encode(f"{config.public_key}:{config.secret_key}".encode("utf-8")).decode("ascii")
+        request.add_header("Authorization", f"Basic {token}")
+        request.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(request, timeout=3) as response:
+            response_body = json.loads(response.read())
+            errors = response_body.get("errors") or []
+            if errors:
+                info(f"span-update partial failure: {json.dumps(errors, ensure_ascii=False)[:500]}")
+    except Exception as e:
+        info(f"ingestion update failed ({len(events)} event(s)): {type(e).__name__}: {e}")
 
 
 def observe_turn(langfuse: Langfuse, trace_span: Any, turn: Turn,

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -10,7 +10,6 @@ Claude Code -> Langfuse hook
 
 """
 
-import base64
 import json
 import logging
 import os
@@ -19,8 +18,6 @@ import sys
 import threading
 import time
 import hashlib
-import urllib.request
-import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
@@ -499,8 +496,9 @@ def read_new_jsonl(transcript_path: Path, session_state: SessionState) -> Tuple[
             session_state.pending_task_notifications = []
             session_state.open_turn = {}
             session_state.turn_numbers = {}
-            # Known limitation: root spans of partially emitted turns stay
-            # provisionally closed in Langfuse when rotation drops their progress.
+            # Known limitation: rotation drops emission progress, so re-read
+            # turns re-emit from scratch; an already-exported root keeps the
+            # output/end time it was emitted with.
             session_state.turn_progress = {}
         with open(transcript_path, "rb") as f:
             f.seek(session_state.offset)
@@ -764,6 +762,44 @@ def get_pending_agent_tool_use_ids(turn: Turn) -> List[str]:
             if is_async_agent_launch_result(tool_result_entry):
                 tool_use_ids.append(tool_use_id)
     return tool_use_ids
+
+
+def get_undelivered_queued_notification_ids(rows: List[Dict[str, Any]]) -> List[str]:
+    """Tool-use ids of task notifications that were enqueued (queue-operation
+    rows) but not yet delivered as a user row.
+
+    A queued result already fills the launch entry's final_content, so the
+    pending-agents check goes clean — yet the turn provably continues: the
+    delivery row and Claude's follow-up response are still outstanding.
+    Queue remove rows carry no notification content and cannot be matched, so
+    a removed notification keeps the gate closed until the turn ends — the
+    safe direction (close-time emission is always correct).
+    """
+    queued: List[str] = []
+    delivered = set()
+    for row in rows:
+        if not is_task_notification_row(row):
+            continue
+        tool_use_id = get_tool_use_id_from_task_notification(row)
+        if not tool_use_id:
+            continue
+        if row.get("type") == "queue-operation":
+            queued.append(tool_use_id)
+        else:
+            delivered.add(tool_use_id)
+    return [tool_use_id for tool_use_id in queued if tool_use_id not in delivered]
+
+
+def turn_has_unresolved_async_activity(turn: Turn) -> bool:
+    """True while the turn's emitted form can provably still change: an async
+    agent has not delivered its final result, or a notification is queued but
+    not yet delivered. Exported roots are immutable, so emission must wait
+    for this gate (or for the turn to close)."""
+    return bool(
+        get_pending_agent_tool_use_ids(turn)
+        or get_undelivered_queued_notification_ids(turn.rows)
+    )
+
 
 def get_turns_to_emit(
     turns: List[Turn],
@@ -2106,9 +2142,9 @@ def open_turn_root_span(langfuse: Langfuse, session_id: str, turn_num: int, turn
                         transcript_path: Path, trace_seed: Optional[str] = None) -> Any:
     """Open the turn's root span, backdated to the user message.
 
-    Kept separate from observe/close so incremental emission can run the
-    phases in different hook invocations: the root span opens on the first
-    firing that sees the turn and closes only when the turn does.
+    The root exports exactly once, at the first firing that is allowed to
+    emit the turn (async activity resolved, or turn closed); later firings
+    only attach children under it via the remote-parent carrier.
 
     With trace_seed set (CC_LANGFUSE_TRACE_SEED) the root adopts the
     externally precomputable trace id derived from seed and turn number;
@@ -2137,77 +2173,6 @@ def open_turn_root_span(langfuse: Langfuse, session_id: str, turn_num: int, turn
     )
 
 
-def queue_root_span_update(update_sink: List[Dict[str, Any]], trace_id: Any, root_span_id: Any,
-                           *, start_time: Optional[datetime] = None,
-                           end_time: Optional[datetime] = None,
-                           input_payload: Any = None, output: Any = None,
-                           metadata: Optional[Dict[str, Any]] = None) -> None:
-    """Queue span-update (+ trace output upsert) events for a provisionally
-    exported root span. Events are sent AFTER the state lock is released
-    (post_ingestion_events) so network latency never blocks other hook runs.
-
-    Callers pass the FULL root payload (name/startTime/input/metadata, not
-    just the changed output/endTime): the ingestion worker may process an
-    update before the original row is queryable, making the update version a
-    standalone row — and whichever version survives the ClickHouse merge
-    must have no holes.
-    """
-    if not is_valid_span_id_hex(root_span_id) or not isinstance(trace_id, str) or not trace_id:
-        return
-    body: Dict[str, Any] = {"id": root_span_id, "traceId": trace_id, "name": "Conversational Turn"}
-    if start_time is not None:
-        body["startTime"] = start_time.isoformat()
-    if input_payload is not None:
-        body["input"] = input_payload
-    if end_time is not None:
-        body["endTime"] = end_time.isoformat()
-    if output is not None:
-        body["output"] = output
-    if metadata is not None:
-        body["metadata"] = metadata
-    now_iso = datetime.now(timezone.utc).isoformat()
-    update_sink.append({
-        "id": str(uuid.uuid4()),
-        "timestamp": now_iso,
-        "type": "span-update",
-        "body": body,
-    })
-    if output is not None:
-        # The trace record derives input/output from the as_root span only at
-        # export time; a later span-update does not refresh it. Upsert the
-        # trace output explicitly so the dashboard header follows.
-        update_sink.append({
-            "id": str(uuid.uuid4()),
-            "timestamp": now_iso,
-            "type": "trace-create",
-            "body": {"id": trace_id, "output": output},
-        })
-
-
-def post_ingestion_events(config: LangfuseConfig, events: List[Dict[str, Any]]) -> None:
-    """Best-effort single POST to the batch ingestion API (fail-open).
-
-    The server upserts by id; it answers 207 even when individual events
-    fail, so the error list is logged explicitly (spike-v2 lesson).
-    """
-    if not events:
-        return
-    try:
-        payload = json.dumps({"batch": events}).encode("utf-8")
-        request = urllib.request.Request(
-            config.host.rstrip("/") + "/api/public/ingestion", data=payload, method="POST"
-        )
-        token = base64.b64encode(f"{config.public_key}:{config.secret_key}".encode("utf-8")).decode("ascii")
-        request.add_header("Authorization", f"Basic {token}")
-        request.add_header("Content-Type", "application/json")
-        with urllib.request.urlopen(request, timeout=3) as response:
-            response_body = json.loads(response.read())
-            errors = response_body.get("errors") or []
-            if errors:
-                info(f"span-update partial failure: {json.dumps(errors, ensure_ascii=False)[:500]}")
-    except Exception as e:
-        info(f"ingestion update failed ({len(events)} event(s)): {type(e).__name__}: {e}")
-
 
 def build_turn_output_payload(turn: Turn) -> Dict[str, Any]:
     last_assistant = turn.assistant_msgs[-1]
@@ -2226,7 +2191,6 @@ def get_root_span_end_time(turn: Turn, obs_end_ts: Optional[datetime]) -> Option
 
 def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
               turn: Turn, transcript_path: Path,
-              update_sink: List[Dict[str, Any]],
               user_id: Optional[str] = None,
               subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
               progress: Optional[Dict[str, Any]] = None,
@@ -2236,9 +2200,13 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
 
     With no progress and close=True this is the classic one-shot emission.
     With close=False only ready observations ship (those whose emitted form
-    can no longer change) and the root span is ended provisionally; a later
-    firing resumes from the returned progress (root span id + emitted keys)
-    and corrects the root via span-update.
+    can no longer change); a later firing resumes from the returned progress
+    (root span id + emitted keys) and adds what is still missing.
+
+    The root span exports exactly once, carrying the output/end time known
+    at that moment — exported spans are immutable, so callers must not emit
+    a turn whose root fields can provably still change (see
+    turn_has_unresolved_async_activity).
     """
     progress = dict(progress or {})
     cursor = EmissionCursor(
@@ -2263,9 +2231,8 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
             parent_otel_span = trace_span._otel_span
         else:
             # Root span exported by an earlier firing: attach children to it
-            # via a carrier and correct the root itself via span-update. The
-            # stored trace id wins over re-derivation so seeded turns resume
-            # into the same trace.
+            # via a carrier. The stored trace id wins over re-derivation so
+            # seeded turns resume into the same trace.
             parent_otel_span = remote_parent(
                 langfuse, session_id, turn.user_msg.get("uuid"),
                 root_span_id=root_span_id, trace_id=progress.get("trace_id"),
@@ -2278,30 +2245,12 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
             subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
             cursor=cursor,
         )
-        end_ts = get_root_span_end_time(turn, obs_end_ts)
-        output = build_turn_output_payload(turn)
         if trace_span is not None:
-            # OTel only exports ended spans, so the root closes now either
-            # way; a non-closing turn gets its final output/end via a later
-            # firing's span-update.
-            trace_span.update(output=output)
-            trace_span.end(end_time=to_otel_nanoseconds(end_ts))
-        elif close or cursor.newly_emitted:
-            # Idle firings send no root update: every update creates a row
-            # version on the server, visible as a transient duplicate root
-            # in the events view until ClickHouse merges the versions.
-            user_text, user_text_meta = truncate_text(
-                extract_text_from_content(get_content_from_row(turn.user_msg))
-            )
-            queue_root_span_update(
-                update_sink, progress.get("trace_id"), root_span_id,
-                start_time=parse_timestamp(turn.user_msg),
-                end_time=end_ts,
-                input_payload={"role": "user", "content": user_text},
-                output=output,
-                metadata=build_trace_metadata(
-                    session_id, turn_num, turn, transcript_path, user_text_meta
-                ),
+            # The root exports exactly once: end time and output are the
+            # values known now, and stay — exported fields are immutable.
+            trace_span.update(output=build_turn_output_payload(turn))
+            trace_span.end(
+                end_time=to_otel_nanoseconds(get_root_span_end_time(turn, obs_end_ts))
             )
     progress["emitted_keys"] = sorted(cursor.emitted)
     return progress
@@ -2322,7 +2271,6 @@ def emit_and_close_ready_turns(
     transcript_path: Path,
     turns_to_emit: List[Turn],
     session_state: SessionState,
-    update_sink: List[Dict[str, Any]],
     *,
     user_id: Optional[str],
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
@@ -2351,7 +2299,6 @@ def emit_and_close_ready_turns(
                 turn_num,
                 turn,
                 transcript_path,
-                update_sink,
                 user_id=user_id,
                 subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
                 progress=progress,
@@ -2371,24 +2318,32 @@ def emit_ready_observations_of_open_turn(
     transcript_path: Path,
     session_state: SessionState,
     task_id_to_tool_use_id: Dict[str, str],
-    update_sink: List[Dict[str, Any]],
     *,
     user_id: Optional[str],
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
     trace_seed: Optional[str] = None,
 ) -> None:
-    """Emit the held open turn's ready observations at this firing (ready =
-    the emitted form can no longer change; see the EmissionCursor gates).
+    """Emit the held open turn once its async activity is provably resolved.
 
-    The turn stays open (rows keep being held); only its emission progress
-    advances in session_state.turn_progress. Turns without a user-row uuid
-    cannot carry progress across firings and keep the close-time behavior.
+    Agent-less turns pass the gate at their own Stop and ship immediately;
+    turns with async activity ship at the first Stop after every agent
+    result has been delivered (empirically: the Stop right after Claude's
+    summary). The turn keeps being held either way; only its emission
+    progress advances in session_state.turn_progress. Exported roots are
+    final — if a turn grows after a clean Stop, later firings still add
+    children, but the root's output/end time stay as emitted.
     """
     held_rows = session_state.open_turn.get("rows") if isinstance(session_state.open_turn, dict) else None
     if not isinstance(held_rows, list) or not held_rows:
         return
     _, trailing_turn, _ = assemble_turns(held_rows, task_id_to_tool_use_id)
     if trailing_turn is None:
+        return
+    if turn_has_unresolved_async_activity(trailing_turn):
+        # The turn provably continues (pending agent result or queued,
+        # undelivered notification). Emitting now would freeze a wrong root
+        # output forever; everything ships at the first clean Stop instead.
+        debug("Open turn held: async activity unresolved (pending agent or undelivered notification)")
         return
     user_row_uuid = trailing_turn.user_msg.get("uuid")
     if not isinstance(user_row_uuid, str) or not user_row_uuid:
@@ -2404,7 +2359,6 @@ def emit_ready_observations_of_open_turn(
             turn_num,
             trailing_turn,
             transcript_path,
-            update_sink,
             user_id=user_id,
             subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
             progress=progress if isinstance(progress, dict) else None,
@@ -2423,9 +2377,6 @@ def emit_new_turns_from_transcript(
     *,
     flush_deferred_agent_turns: bool = False,
 ) -> int:
-    # Ingestion updates are only collected while the lock is held and POSTed
-    # afterwards: network latency must never block concurrent hook runs.
-    update_sink: List[Dict[str, Any]] = []
     with FileLock(LOCK_FILE):
         state = load_hook_state()
         key = get_session_state_key(session_id, str(transcript_path))
@@ -2455,7 +2406,6 @@ def emit_new_turns_from_transcript(
                 transcript_path,
                 turns_to_emit,
                 session_state,
-                update_sink,
                 user_id=config.user_id,
                 subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
                 trace_seed=config.trace_seed,
@@ -2463,15 +2413,15 @@ def emit_new_turns_from_transcript(
 
         session_state.turn_count += emitted
 
-        # D1: the still-open trailing turn emits its ready observations at
-        # every firing; its trace appears at the first Stop and grows.
+        # The still-open trailing turn ships once its async activity is
+        # provably resolved (agent-less turns: at their own Stop); until
+        # then its rows keep being held and nothing is emitted.
         emit_ready_observations_of_open_turn(
             langfuse,
             session_id,
             transcript_path,
             session_state,
             get_task_id_to_tool_use_id(subagent_transcripts_by_tool_use_id),
-            update_sink,
             user_id=config.user_id,
             subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
             trace_seed=config.trace_seed,
@@ -2483,7 +2433,6 @@ def emit_new_turns_from_transcript(
         # never reached the server.
         save_session_state(state, key, session_state)
 
-    post_ingestion_events(config, update_sink)
     return emitted
 
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -468,6 +468,12 @@ def read_new_jsonl(transcript_path: Path, session_state: SessionState) -> Tuple[
             debug(f"transcript shrank ({file_size} < {session_state.offset}); restarting")
             session_state.offset = 0
             session_state.buffer = ""
+            # The held rows refer to the replaced file; re-reading from byte 0
+            # would emit those turns a second time (and mix old rows into the
+            # new stream), so drop all persisted turn state along with the offset.
+            session_state.pending_agent_turns = []
+            session_state.pending_task_notifications = []
+            session_state.open_turn_rows = []
         with open(transcript_path, "rb") as f:
             f.seek(session_state.offset)
             chunk = f.read()

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1905,11 +1905,18 @@ def emit_ready_turns(
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
 ) -> int:
     emitted = 0
+    # Turns without a user-row uuid bypass assign_turn_numbers; seed their
+    # fallback from the same monotonic sequence so numbers never collide.
+    next_fallback_turn_number = 1 + max(
+        session_state.turn_count,
+        max(session_state.turn_numbers.values(), default=0),
+    )
     for turn in turns_to_emit:
         emitted += 1
-        turn_num = session_state.turn_numbers.get(
-            turn.user_msg.get("uuid"), session_state.turn_count + emitted
-        )
+        turn_num = session_state.turn_numbers.get(turn.user_msg.get("uuid"))
+        if turn_num is None:
+            turn_num = next_fallback_turn_number
+            next_fallback_turn_number += 1
         try:
             emit_turn(
                 langfuse,

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1817,48 +1817,66 @@ def deterministic_trace_parent(langfuse: Langfuse, session_id: str, turn: Turn) 
         return None
 
 
+def open_turn_root_span(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn,
+                        transcript_path: Path) -> Any:
+    """Open the turn's root span, backdated to the user message.
+
+    Kept separate from observe/close so incremental emission can run the
+    phases in different hook invocations: the root span opens on the first
+    firing that sees the turn and closes only when the turn does.
+    """
+    user_text_raw = extract_text_from_content(get_content_from_row(turn.user_msg))
+    user_text, user_text_meta = truncate_text(user_text_raw)
+    trace_metadata = build_trace_metadata(session_id, turn_num, turn, transcript_path, user_text_meta)
+    return _start_backdated(
+        langfuse,
+        name="Conversational Turn",
+        as_type="span",
+        start_time=parse_timestamp(turn.user_msg),
+        parent_otel_span=deterministic_trace_parent(langfuse, session_id, turn),
+        input={"role": "user", "content": user_text},
+        metadata=trace_metadata,
+    )
+
+
+def observe_turn(langfuse: Langfuse, trace_span: Any, turn: Turn,
+                 subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]]) -> Optional[datetime]:
+    """Emit the turn's generations and tool observations under its root span."""
+    return emit_turn_observations(
+        langfuse,
+        trace_span._otel_span,
+        turn,
+        parse_timestamp(turn.user_msg),
+        subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+    )
+
+
+def close_turn_root_span(trace_span: Any, turn: Turn, obs_end_ts: Optional[datetime]) -> None:
+    """Close the turn's root span with its final output and end time."""
+    last_assistant = turn.assistant_msgs[-1]
+    final_assistant_text, _ = truncate_text(extract_text_from_content(get_content_from_row(last_assistant)))
+    trace_span.update(output={"role": "assistant", "content": final_assistant_text})
+    end_ts = _get_latest_timestamp(
+        get_turn_end_timestamp(turn),
+        parse_timestamp(last_assistant),
+        obs_end_ts,
+        parse_timestamp(turn.user_msg),
+    )
+    trace_span.end(end_time=to_otel_nanoseconds(end_ts))
+
+
 def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, transcript_path: Path,
               user_id: Optional[str] = None,
               subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
-    user_text_raw = extract_text_from_content(get_content_from_row(turn.user_msg))
-    user_text, user_text_meta = truncate_text(user_text_raw)
-
-    last_assistant = turn.assistant_msgs[-1]
-    final_assistant_text, _ = truncate_text(extract_text_from_content(get_content_from_row(last_assistant)))
-
-    user_ts = parse_timestamp(turn.user_msg)
-    last_assistant_ts = parse_timestamp(last_assistant)
-    turn_end_ts = get_turn_end_timestamp(turn)
-    trace_metadata = build_trace_metadata(session_id, turn_num, turn, transcript_path, user_text_meta)
-    tags = get_trace_tags(turn)
-
-    trace_name = trace_display_name(session_id, turn_num)
-    root_observation_name = "Conversational Turn"
-
     with propagate_attributes(
         session_id=session_id,
         user_id=user_id,
-        trace_name=trace_name,
-        tags=tags,
+        trace_name=trace_display_name(session_id, turn_num),
+        tags=get_trace_tags(turn),
     ):
-        trace_span = _start_backdated(
-            langfuse,
-            name=root_observation_name,
-            as_type="span",
-            start_time=user_ts,
-            parent_otel_span=deterministic_trace_parent(langfuse, session_id, turn),
-            input={"role": "user", "content": user_text},
-            metadata=trace_metadata,
-        )
-        obs_end_ts = emit_turn_observations(
-            langfuse,
-            trace_span._otel_span,
-            turn,
-            user_ts,
-            subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
-        )
-        trace_span.update(output={"role": "assistant", "content": final_assistant_text})
-        trace_span.end(end_time=to_otel_nanoseconds(_get_latest_timestamp(turn_end_ts, last_assistant_ts, obs_end_ts, user_ts)))
+        trace_span = open_turn_root_span(langfuse, session_id, turn_num, turn, transcript_path)
+        obs_end_ts = observe_turn(langfuse, trace_span, turn, subagent_transcripts_by_tool_use_id)
+        close_turn_root_span(trace_span, turn, obs_end_ts)
 
 
 # ---- New turn emission orchestration ----

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -276,6 +276,9 @@ class SessionState:
     # within one logical turn (task notifications, blocking hooks), so the
     # trailing turn stays open until a new user row or SessionEnd closes it.
     open_turn_rows: List[Dict[str, Any]] = field(default_factory=list)
+    # Turn numbers assigned when a turn is first seen (keyed by its user-row
+    # uuid), so a turn keeps its number regardless of when it is emitted.
+    turn_numbers: Dict[str, int] = field(default_factory=dict)
 
 def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     s = global_state.get(key, {})
@@ -288,6 +291,9 @@ def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     open_turn_rows = s.get("open_turn_rows")
     if not isinstance(open_turn_rows, list):
         open_turn_rows = []
+    turn_numbers = s.get("turn_numbers")
+    if not isinstance(turn_numbers, dict):
+        turn_numbers = {}
     return SessionState(
         offset=int(s.get("offset", 0)),
         buffer=str(s.get("buffer", "")),
@@ -295,6 +301,7 @@ def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
         pending_agent_turns=pending_agent_turns,
         pending_task_notifications=pending_task_notifications,
         open_turn_rows=open_turn_rows,
+        turn_numbers=turn_numbers,
     )
 
 def update_session_state(global_state: Dict[str, Any], key: str, session_state: SessionState) -> None:
@@ -305,6 +312,7 @@ def update_session_state(global_state: Dict[str, Any], key: str, session_state: 
         "pending_agent_turns": session_state.pending_agent_turns or [],
         "pending_task_notifications": session_state.pending_task_notifications or [],
         "open_turn_rows": session_state.open_turn_rows or [],
+        "turn_numbers": session_state.turn_numbers or {},
         "updated": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -475,6 +483,7 @@ def read_new_jsonl(transcript_path: Path, session_state: SessionState) -> Tuple[
             session_state.pending_agent_turns = []
             session_state.pending_task_notifications = []
             session_state.open_turn_rows = []
+            session_state.turn_numbers = {}
         with open(transcript_path, "rb") as f:
             f.seek(session_state.offset)
             chunk = f.read()
@@ -982,6 +991,19 @@ def build_turns(
     return turns
 
 
+def assign_turn_numbers(turns: List[Turn], trailing_turn: Optional[Turn],
+                        session_state: SessionState) -> None:
+    """Assigns each turn its number the first time it is seen (in transcript
+    order). Keyed by the turn's user-row uuid."""
+    trailing = [trailing_turn] if trailing_turn is not None else []
+    for turn in turns + trailing:
+        user_row_uuid = turn.user_msg.get("uuid")
+        if not isinstance(user_row_uuid, str) or not user_row_uuid:
+            continue
+        if user_row_uuid not in session_state.turn_numbers:
+            session_state.turn_numbers[user_row_uuid] = len(session_state.turn_numbers) + 1
+
+
 def get_new_turns_from_transcript(
     transcript_path: Path,
     session_state: SessionState,
@@ -1036,6 +1058,7 @@ def get_new_turns_from_transcript(
         if trailing_turn_rows:
             debug(f"Holding trailing open turn ({len(trailing_turn_rows)} row(s)) until a new user row closes it")
 
+    assign_turn_numbers(turns, trailing_turn, session_state)
     return turns, session_state
 
 def get_subagent_transcripts_by_tool_use_id(transcript_path: Path) -> Dict[str, Dict[str, Any]]:
@@ -1833,7 +1856,9 @@ def emit_ready_turns(
     emitted = 0
     for turn in turns_to_emit:
         emitted += 1
-        turn_num = session_state.turn_count + emitted
+        turn_num = session_state.turn_numbers.get(
+            turn.user_msg.get("uuid"), session_state.turn_count + emitted
+        )
         try:
             emit_turn(
                 langfuse,

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -2159,6 +2159,14 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
 
 
 # ---- New turn emission orchestration ----
+def pop_turn_progress(session_state: SessionState, turn: Turn) -> Optional[Dict[str, Any]]:
+    user_row_uuid = turn.user_msg.get("uuid")
+    if not isinstance(user_row_uuid, str) or not user_row_uuid:
+        return None
+    entry = session_state.turn_progress.pop(user_row_uuid, None)
+    return entry if isinstance(entry, dict) else None
+
+
 def emit_and_close_ready_turns(
     langfuse: Langfuse,
     session_id: str,
@@ -2183,6 +2191,9 @@ def emit_and_close_ready_turns(
         if turn_num is None:
             turn_num = next_fallback_turn_number
             next_fallback_turn_number += 1
+        # Progress from firings while this turn was still open; closing the
+        # turn consumes it so the emitted keys don't outlive the turn.
+        progress = pop_turn_progress(session_state, turn)
         try:
             emit_turn(
                 langfuse,
@@ -2193,7 +2204,7 @@ def emit_and_close_ready_turns(
                 update_sink,
                 user_id=user_id,
                 subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
-                progress=None,
+                progress=progress,
                 close=True,
             )
         except Exception as e:
@@ -2202,6 +2213,54 @@ def emit_and_close_ready_turns(
             info(f"emit_turn failed: {type(e).__name__}: {e}")
     return emitted
 
+
+def emit_ready_observations_of_open_turn(
+    langfuse: Langfuse,
+    session_id: str,
+    transcript_path: Path,
+    session_state: SessionState,
+    task_id_to_tool_use_id: Dict[str, str],
+    update_sink: List[Dict[str, Any]],
+    *,
+    user_id: Optional[str],
+    subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
+) -> None:
+    """Emit the held open turn's ready observations at this firing (ready =
+    the emitted form can no longer change; see the EmissionCursor gates).
+
+    The turn stays open (rows keep being held); only its emission progress
+    advances in session_state.turn_progress. Turns without a user-row uuid
+    cannot carry progress across firings and keep the close-time behavior.
+    """
+    held_rows = session_state.open_turn.get("rows") if isinstance(session_state.open_turn, dict) else None
+    if not isinstance(held_rows, list) or not held_rows:
+        return
+    _, trailing_turn, _ = assemble_turns(held_rows, task_id_to_tool_use_id)
+    if trailing_turn is None:
+        return
+    user_row_uuid = trailing_turn.user_msg.get("uuid")
+    if not isinstance(user_row_uuid, str) or not user_row_uuid:
+        return
+    turn_num = session_state.turn_numbers.get(user_row_uuid)
+    if turn_num is None:
+        return
+    progress = session_state.turn_progress.get(user_row_uuid)
+    try:
+        progress = emit_turn(
+            langfuse,
+            session_id,
+            turn_num,
+            trailing_turn,
+            transcript_path,
+            update_sink,
+            user_id=user_id,
+            subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+            progress=progress if isinstance(progress, dict) else None,
+            close=False,
+        )
+        session_state.turn_progress[user_row_uuid] = progress
+    except Exception as e:
+        info(f"emitting ready observations of open turn failed: {type(e).__name__}: {e}")
 
 def emit_new_turns_from_transcript(
     langfuse: Langfuse,
@@ -2229,27 +2288,44 @@ def emit_new_turns_from_transcript(
             subagent_transcripts_by_tool_use_id,
             flush_deferred_agent_turns=flush_deferred_agent_turns,
         )
-        if not turns:
-            save_session_state(state, key, session_state)
-            return 0
 
-        turns_to_emit = get_turns_to_emit(
-            turns,
-            session_state,
-            flush_deferred_agent_turns=flush_deferred_agent_turns,
-        )
-        emitted = emit_and_close_ready_turns(
+        emitted = 0
+        if turns:
+            turns_to_emit = get_turns_to_emit(
+                turns,
+                session_state,
+                flush_deferred_agent_turns=flush_deferred_agent_turns,
+            )
+            emitted = emit_and_close_ready_turns(
+                langfuse,
+                session_id,
+                transcript_path,
+                turns_to_emit,
+                session_state,
+                update_sink,
+                user_id=config.user_id,
+                subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+            )
+
+        session_state.turn_count += emitted
+
+        # D1: the still-open trailing turn emits its ready observations at
+        # every firing; its trace appears at the first Stop and grows.
+        emit_ready_observations_of_open_turn(
             langfuse,
             session_id,
             transcript_path,
-            turns_to_emit,
             session_state,
+            get_task_id_to_tool_use_id(subagent_transcripts_by_tool_use_id),
             update_sink,
             user_id=config.user_id,
             subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
         )
 
-        session_state.turn_count += emitted
+        # Known limitation (accepted, like the crash-between-emit-and-save
+        # duplicate window): progress is persisted before the SDK flush in
+        # main(); a dropped flush leaves emitted_keys pointing at spans that
+        # never reached the server.
         save_session_state(state, key, session_state)
 
     post_ingestion_events(config, update_sink)

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1196,6 +1196,13 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
         # parentSpanId that never exports, so the server only treats them as
         # the trace root (deriving trace input/output/name) with this marker.
         otel_span.set_attribute("langfuse.internal.as_root", True)
+    else:
+        # The SDK span processor auto-marks spans whose parent this process
+        # never exported as langfuse.internal.is_app_root — true for every
+        # continuation-firing child under the carrier, which then shows up as
+        # a root in the events view. Children are never app roots; overriding
+        # the attribute wins over the processor's earlier write.
+        otel_span.set_attribute("langfuse.internal.is_app_root", False)
     return langfuse._create_observation_from_otel_span(
         otel_span=otel_span,
         as_type=as_type,

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1192,10 +1192,15 @@ def get_task_id_to_tool_use_id(
 
 # ---- Low-level Langfuse helpers ----
 def to_otel_nanoseconds(ts: Optional[datetime]) -> Optional[int]:
-    """Convert a datetime to OTel-style nanoseconds since epoch."""
+    """Convert a datetime to OTel-style nanoseconds since epoch.
+
+    Rounded at microsecond precision: naive float math (timestamp() * 1e9
+    truncated with int()) lands just below the exact millisecond for many
+    values, shifting emitted times by -1ms vs the transcript.
+    """
     if ts is None:
         return None
-    return int(ts.timestamp() * 1_000_000_000)
+    return round(ts.timestamp() * 1_000_000) * 1_000
 
 def _get_latest_timestamp(*timestamps: Optional[datetime]) -> Optional[datetime]:
     present_timestamps = [timestamp for timestamp in timestamps if timestamp is not None]

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -272,10 +272,9 @@ class SessionState:
     # Task-notification rows whose tool_use_id could not be resolved yet
     # (task-id-only and the subagent meta.json not on disk); retried each run.
     pending_task_notifications: List[Dict[str, Any]] = field(default_factory=list)
-    # Rows of the trailing turn of the last batch. Stop fires multiple times
-    # within one logical turn (task notifications, blocking hooks), so the
-    # trailing turn stays open until a new user row or SessionEnd closes it.
-    open_turn_rows: List[Dict[str, Any]] = field(default_factory=list)
+    # Trailing turn kept while it may still continue; see build_open_turn
+    # for the structure (rows plus emission cursor).
+    open_turn: Dict[str, Any] = field(default_factory=dict)
     # Turn numbers assigned when a turn is first seen (keyed by its user-row
     # uuid), so a turn keeps its number regardless of when it is emitted.
     turn_numbers: Dict[str, int] = field(default_factory=dict)
@@ -288,9 +287,9 @@ def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     pending_task_notifications = s.get("pending_task_notifications")
     if not isinstance(pending_task_notifications, list):
         pending_task_notifications = []
-    open_turn_rows = s.get("open_turn_rows")
-    if not isinstance(open_turn_rows, list):
-        open_turn_rows = []
+    open_turn = s.get("open_turn")
+    if not isinstance(open_turn, dict):
+        open_turn = {}
     turn_numbers = s.get("turn_numbers")
     if not isinstance(turn_numbers, dict):
         turn_numbers = {}
@@ -300,7 +299,7 @@ def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
         turn_count=int(s.get("turn_count", 0)),
         pending_agent_turns=pending_agent_turns,
         pending_task_notifications=pending_task_notifications,
-        open_turn_rows=open_turn_rows,
+        open_turn=open_turn,
         turn_numbers=turn_numbers,
     )
 
@@ -311,7 +310,7 @@ def update_session_state(global_state: Dict[str, Any], key: str, session_state: 
         "turn_count": session_state.turn_count,
         "pending_agent_turns": session_state.pending_agent_turns or [],
         "pending_task_notifications": session_state.pending_task_notifications or [],
-        "open_turn_rows": session_state.open_turn_rows or [],
+        "open_turn": session_state.open_turn or {},
         "turn_numbers": session_state.turn_numbers or {},
         "updated": datetime.now(timezone.utc).isoformat(),
     }
@@ -482,7 +481,7 @@ def read_new_jsonl(transcript_path: Path, session_state: SessionState) -> Tuple[
             # new stream), so drop all persisted turn state along with the offset.
             session_state.pending_agent_turns = []
             session_state.pending_task_notifications = []
-            session_state.open_turn_rows = []
+            session_state.open_turn = {}
             session_state.turn_numbers = {}
         with open(transcript_path, "rb") as f:
             f.seek(session_state.offset)
@@ -991,6 +990,24 @@ def build_turns(
     return turns
 
 
+def build_open_turn(trailing_turn: Optional[Turn],
+                    trailing_turn_rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Package the trailing turn for the session state; emitted_keys and
+    root_span_id are the (yet unused) slots for the emission cursor."""
+    if not trailing_turn_rows:
+        return {}
+    if trailing_turn is not None:
+        user_row_uuid = trailing_turn.user_msg.get("uuid")
+    else:
+        user_row_uuid = trailing_turn_rows[0].get("uuid")
+    return {
+        "user_row_uuid": user_row_uuid,
+        "rows": trailing_turn_rows,
+        "emitted_keys": [],
+        "root_span_id": None,
+    }
+
+
 def assign_turn_numbers(turns: List[Turn], trailing_turn: Optional[Turn],
                         session_state: SessionState) -> None:
     """Assigns each turn its number the first time it is seen (in transcript
@@ -1019,9 +1036,11 @@ def get_new_turns_from_transcript(
     # user-less continuation rows (task notifications, assistant rows); with
     # the open turn's rows in front they attach to it instead of being
     # dropped by turn assembly.
-    if session_state.open_turn_rows:
-        rows = session_state.open_turn_rows + rows
-        session_state.open_turn_rows = []
+    previous_open_turn = session_state.open_turn if isinstance(session_state.open_turn, dict) else {}
+    held_rows = previous_open_turn.get("rows")
+    if isinstance(held_rows, list) and held_rows:
+        rows = held_rows + rows
+        session_state.open_turn = {}
 
     deferred_turn_row_lists, rows = resolve_deferred_agent_turns(rows, session_state, task_id_to_tool_use_id)
 
@@ -1054,7 +1073,7 @@ def get_new_turns_from_transcript(
         if trailing_turn is not None:
             turns.append(trailing_turn)
     else:
-        session_state.open_turn_rows = trailing_turn_rows
+        session_state.open_turn = build_open_turn(trailing_turn, trailing_turn_rows)
         if trailing_turn_rows:
             debug(f"Holding trailing open turn ({len(trailing_turn_rows)} row(s)) until a new user row closes it")
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1011,14 +1011,21 @@ def build_open_turn(trailing_turn: Optional[Turn],
 def assign_turn_numbers(turns: List[Turn], trailing_turn: Optional[Turn],
                         session_state: SessionState) -> None:
     """Assigns each turn its number the first time it is seen (in transcript
-    order). Keyed by the turn's user-row uuid."""
+    order). Keyed by the turn's user-row uuid. Numbering seeds past
+    max(turn_count, highest assigned) so a cleared or missing turn_numbers
+    dict (rotation, legacy state files) cannot restart numbering at 1."""
     trailing = [trailing_turn] if trailing_turn is not None else []
+    next_turn_number = 1 + max(
+        session_state.turn_count,
+        max(session_state.turn_numbers.values(), default=0),
+    )
     for turn in turns + trailing:
         user_row_uuid = turn.user_msg.get("uuid")
         if not isinstance(user_row_uuid, str) or not user_row_uuid:
             continue
         if user_row_uuid not in session_state.turn_numbers:
-            session_state.turn_numbers[user_row_uuid] = len(session_state.turn_numbers) + 1
+            session_state.turn_numbers[user_row_uuid] = next_turn_number
+            next_turn_number += 1
 
 
 def get_new_turns_from_transcript(

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -2007,6 +2007,7 @@ def main() -> int:
 
     config = get_langfuse_config()
     if config is None:
+        debug("No LANGFUSE_PUBLIC_KEY/SECRET_KEY in environment; nothing to do")
         return 0
 
     payload = read_hook_payload()

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -278,6 +278,11 @@ class SessionState:
     # Turn numbers assigned when a turn is first seen (keyed by its user-row
     # uuid), so a turn keeps its number regardless of when it is emitted.
     turn_numbers: Dict[str, int] = field(default_factory=dict)
+    # Per-turn emission progress (keyed by user-row uuid): trace_id,
+    # root_span_id and the keys of already-emitted observations. Carries a
+    # partially emitted turn across firings and across the open -> closed ->
+    # deferred transitions; entries are dropped once the turn is finalized.
+    turn_progress: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
 def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     s = global_state.get(key, {})
@@ -293,6 +298,9 @@ def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     turn_numbers = s.get("turn_numbers")
     if not isinstance(turn_numbers, dict):
         turn_numbers = {}
+    turn_progress = s.get("turn_progress")
+    if not isinstance(turn_progress, dict):
+        turn_progress = {}
     return SessionState(
         offset=int(s.get("offset", 0)),
         buffer=str(s.get("buffer", "")),
@@ -301,6 +309,7 @@ def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
         pending_task_notifications=pending_task_notifications,
         open_turn=open_turn,
         turn_numbers=turn_numbers,
+        turn_progress=turn_progress,
     )
 
 def update_session_state(global_state: Dict[str, Any], key: str, session_state: SessionState) -> None:
@@ -312,6 +321,7 @@ def update_session_state(global_state: Dict[str, Any], key: str, session_state: 
         "pending_task_notifications": session_state.pending_task_notifications or [],
         "open_turn": session_state.open_turn or {},
         "turn_numbers": session_state.turn_numbers or {},
+        "turn_progress": session_state.turn_progress or {},
         "updated": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -483,6 +493,9 @@ def read_new_jsonl(transcript_path: Path, session_state: SessionState) -> Tuple[
             session_state.pending_task_notifications = []
             session_state.open_turn = {}
             session_state.turn_numbers = {}
+            # Known limitation: root spans of partially emitted turns stay
+            # provisionally closed in Langfuse when rotation drops their progress.
+            session_state.turn_progress = {}
         with open(transcript_path, "rb") as f:
             f.seek(session_state.offset)
             chunk = f.read()
@@ -992,8 +1005,9 @@ def build_turns(
 
 def build_open_turn(trailing_turn: Optional[Turn],
                     trailing_turn_rows: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Package the trailing turn for the session state; emitted_keys and
-    root_span_id are the (yet unused) slots for the emission cursor."""
+    """Package the trailing turn for the session state. Emission progress is
+    NOT kept here: it lives in session_state.turn_progress (keyed by the
+    user-row uuid) so it survives the open -> closed -> deferred transitions."""
     if not trailing_turn_rows:
         return {}
     if trailing_turn is not None:
@@ -1003,8 +1017,6 @@ def build_open_turn(trailing_turn: Optional[Turn],
     return {
         "user_row_uuid": user_row_uuid,
         "rows": trailing_turn_rows,
-        "emitted_keys": [],
-        "root_span_id": None,
     }
 
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1150,6 +1150,7 @@ def _get_latest_timestamp(*timestamps: Optional[datetime]) -> Optional[datetime]
 def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
                      start_time: Optional[datetime],
                      parent_otel_span: Any = None,
+                     as_root: bool = False,
                      **obs_kwargs: Any) -> Any:
     """Create a Langfuse observation with an explicit OTel start_time.
 
@@ -1178,6 +1179,11 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
             otel_span = langfuse._otel_tracer.start_span(name=name, start_time=start_ns)
     else:
         otel_span = langfuse._otel_tracer.start_span(name=name, start_time=start_ns)
+    if as_root:
+        # SDK/server contract: spans under a synthetic trace-id carrier have a
+        # parentSpanId that never exports, so the server only treats them as
+        # the trace root (deriving trace input/output/name) with this marker.
+        otel_span.set_attribute("langfuse.internal.as_root", True)
     return langfuse._create_observation_from_otel_span(
         otel_span=otel_span,
         as_type=as_type,
@@ -1841,6 +1847,7 @@ def open_turn_root_span(langfuse: Langfuse, session_id: str, turn_num: int, turn
         as_type="span",
         start_time=parse_timestamp(turn.user_msg),
         parent_otel_span=deterministic_trace_parent(langfuse, session_id, turn),
+        as_root=True,
         input={"role": "user", "content": user_text},
         metadata=trace_metadata,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,10 @@ class FakeOtelSpan:
     def __init__(self, name: str, start_time: int | None) -> None:
         self.name = name
         self.start_time = start_time
+        self.attributes: dict[str, Any] = {}
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
 
 
 class FakeTracer:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import itertools
 import importlib.util
 import json
 import sys
@@ -108,6 +109,9 @@ class FakeTracer:
         return FakeOtelSpan(name, start_time)
 
 
+_fake_observation_counter = itertools.count(1)
+
+
 class FakeObservation:
     def __init__(self, otel_span: FakeOtelSpan, as_type: str, kwargs: dict[str, Any]) -> None:
         self._otel_span = otel_span
@@ -116,6 +120,10 @@ class FakeObservation:
         self.kwargs = kwargs
         self.output: Any = None
         self.end_time: int | None = None
+        # Mirror the SDK's hex id/trace_id attributes (span.py sets both).
+        n = next(_fake_observation_counter)
+        self.id = f"{n:016x}"
+        self.trace_id = f"{n:032x}"
 
     def update(self, **kwargs: Any) -> None:
         if "output" in kwargs:
@@ -152,6 +160,15 @@ class FakeLangfuse:
 @pytest.fixture
 def fake_langfuse() -> FakeLangfuse:
     return FakeLangfuse()
+
+
+@pytest.fixture(autouse=True)
+def recorded_ingestion_events(hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Keep the suite hermetic: the post-lock ingestion POST never reaches the
+    network; tests can assert on the recorded span-update/trace-create events."""
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setattr(hook_module, "post_ingestion_events", lambda config, events: sent.extend(events))
+    return sent
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import importlib.util
 import json
 import sys
@@ -36,7 +37,27 @@ def _install_langfuse_stubs() -> None:
     def use_span(*_: Any, **__: Any) -> Iterator[None]:
         yield
 
+    class SpanContext:
+        def __init__(self, *, trace_id: int, span_id: int, trace_flags: int, is_remote: bool) -> None:
+            self.trace_id = trace_id
+            self.span_id = span_id
+            self.trace_flags = trace_flags
+            self.is_remote = is_remote
+
+    class TraceFlags(int):
+        pass
+
+    class NonRecordingSpan:
+        def __init__(self, context: SpanContext) -> None:
+            self._context = context
+
+        def get_span_context(self) -> SpanContext:
+            return self._context
+
     trace_module.use_span = use_span
+    trace_module.SpanContext = SpanContext
+    trace_module.TraceFlags = TraceFlags
+    trace_module.NonRecordingSpan = NonRecordingSpan
     opentelemetry_module.trace = trace_module
     sys.modules["opentelemetry"] = opentelemetry_module
     sys.modules["opentelemetry.trace"] = trace_module
@@ -109,6 +130,12 @@ class FakeLangfuse:
     def __init__(self) -> None:
         self._otel_tracer = FakeTracer()
         self.observations: list[FakeObservation] = []
+
+    @staticmethod
+    def create_trace_id(*, seed: str | None = None) -> str:
+        # Mirrors SDK 4.x: sha256(seed).digest()[:16].hex()
+        assert seed, "tests always pass a seed"
+        return hashlib.sha256(seed.encode("utf-8")).digest()[:16].hex()
 
     def _create_observation_from_otel_span(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,15 +172,6 @@ def fake_langfuse() -> FakeLangfuse:
     return FakeLangfuse()
 
 
-@pytest.fixture(autouse=True)
-def recorded_ingestion_events(hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
-    """Keep the suite hermetic: the post-lock ingestion POST never reaches the
-    network; tests can assert on the recorded span-update/trace-create events."""
-    sent: list[dict[str, Any]] = []
-    monkeypatch.setattr(hook_module, "post_ingestion_events", lambda config, events: sent.extend(events))
-    return sent
-
-
 @pytest.fixture
 def isolated_hook_state(tmp_path: Path, hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> Path:
     state_dir = tmp_path / "claude-state"

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -79,6 +79,31 @@ def test_emit_new_turns_defers_async_agent_until_session_end_flush(
     assert next(iter(state.values()))["pending_agent_turns"] == []
 
 
+def test_idle_firings_send_no_root_updates(
+    hook_module,
+    fixture_transcript_path,
+    fake_langfuse,
+    isolated_hook_state,
+    recorded_ingestion_events,
+):
+    # Every queued update becomes a row version server-side; idle firings
+    # (nothing newly emitted) must therefore stay silent, close must not.
+    transcript = fixture_transcript_path("async_agent_deferred")
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-gate", transcript)
+    after_first_firing = len(recorded_ingestion_events)
+
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-gate", transcript)
+    assert len(recorded_ingestion_events) == after_first_firing
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-gate", transcript, flush_deferred_agent_turns=True
+    )
+    update_types = [e["type"] for e in recorded_ingestion_events[after_first_firing:]]
+    assert "span-update" in update_types
+
+
 def test_only_the_turn_root_span_is_marked_as_root(
     hook_module,
     fixture_transcript_path,

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -23,7 +23,7 @@ def test_emit_new_turns_from_completed_async_agent_transcript(
 
     assert emitted == 0
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
-    assert next(iter(state.values()))["open_turn_rows"] != []
+    assert next(iter(state.values()))["open_turn"]["rows"]
 
     # SessionEnd closes it.
     emitted = hook_module.emit_new_turns_from_transcript(
@@ -39,7 +39,7 @@ def test_emit_new_turns_from_completed_async_agent_transcript(
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     assert next(iter(state.values()))["turn_count"] == 1
     assert next(iter(state.values()))["pending_agent_turns"] == []
-    assert next(iter(state.values()))["open_turn_rows"] == []
+    assert next(iter(state.values()))["open_turn"] == {}
 
 
 def test_emit_new_turns_defers_async_agent_until_session_end_flush(
@@ -63,7 +63,7 @@ def test_emit_new_turns_defers_async_agent_until_session_end_flush(
     assert emitted == 0
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     assert next(iter(state.values()))["pending_agent_turns"] == []
-    assert next(iter(state.values()))["open_turn_rows"] != []
+    assert next(iter(state.values()))["open_turn"]["rows"]
 
     emitted = hook_module.emit_new_turns_from_transcript(
         fake_langfuse,

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -79,29 +79,65 @@ def test_emit_new_turns_defers_async_agent_until_session_end_flush(
     assert next(iter(state.values()))["pending_agent_turns"] == []
 
 
-def test_idle_firings_send_no_root_updates(
+def test_open_agent_turn_emits_only_after_notification_delivery(
     hook_module,
-    fixture_transcript_path,
     fake_langfuse,
     isolated_hook_state,
-    recorded_ingestion_events,
+    tmp_path,
 ):
-    # Every queued update becomes a row version server-side; idle firings
-    # (nothing newly emitted) must therefore stay silent, close must not.
-    transcript = fixture_transcript_path("async_agent_deferred")
+    """Exported roots are immutable, so an agent turn must not ship while its
+    result is only queued; it ships once, with the real final output, at the
+    first firing after delivery + Claude's follow-up response."""
+    notification = (
+        "<task-notification>\n<task-id>task-1</task-id>\n"
+        "<tool-use-id>toolu_agent1</tool-use-id>\n"
+        "<status>completed</status>\n<result>42 Ergebnisse</result>\n</task-notification>"
+    )
+    rows = [
+        {"type": "user", "uuid": "user-1", "timestamp": "2026-01-01T00:00:00.000Z",
+         "sessionId": "s", "message": {"role": "user", "content": "Starte einen Agent."}},
+        {"type": "assistant", "uuid": "a-1", "timestamp": "2026-01-01T00:00:01.000Z",
+         "message": {"id": "msg-1", "role": "assistant", "model": "claude-test",
+                     "content": [{"type": "tool_use", "id": "toolu_agent1", "name": "Agent",
+                                  "input": {"prompt": "recherchiere"}}]}},
+        {"type": "user", "uuid": "tr-1", "timestamp": "2026-01-01T00:00:02.000Z",
+         "toolUseResult": {"status": "async_launched", "isAsync": True},
+         "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_agent1",
+                     "content": [{"type": "text", "text": "Async agent launched successfully."}]}]}},
+        {"type": "queue-operation", "operation": "enqueue",
+         "timestamp": "2026-01-01T00:00:03.000Z", "content": notification},
+        {"type": "assistant", "uuid": "a-2", "timestamp": "2026-01-01T00:00:04.000Z",
+         "message": {"id": "msg-2", "role": "assistant", "model": "claude-test",
+                     "content": [{"type": "text", "text": "Der Agent laeuft im Hintergrund."}]}},
+    ]
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
     config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
 
-    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-gate", transcript)
-    after_first_firing = len(recorded_ingestion_events)
+    def roots():
+        return [o for o in fake_langfuse.observations if o.name == "Conversational Turn"]
 
+    # Firing 1: the result is only queued, not delivered — the turn provably
+    # continues, so nothing may be exported yet.
     hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-gate", transcript)
-    assert len(recorded_ingestion_events) == after_first_firing
+    assert roots() == []
 
-    hook_module.emit_new_turns_from_transcript(
-        fake_langfuse, config, "session-gate", transcript, flush_deferred_agent_turns=True
-    )
-    update_types = [e["type"] for e in recorded_ingestion_events[after_first_firing:]]
-    assert "span-update" in update_types
+    with transcript.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"type": "user", "uuid": "n-1", "timestamp": "2026-01-01T00:00:05.000Z",
+                            "origin": {"kind": "task-notification"},
+                            "message": {"role": "user", "content": notification}}) + "\n")
+        f.write(json.dumps({"type": "assistant", "uuid": "a-3", "timestamp": "2026-01-01T00:00:06.000Z",
+                            "message": {"id": "msg-3", "role": "assistant", "model": "claude-test",
+                                        "content": [{"type": "text", "text": "Fertig: 42 Ergebnisse."}]}}) + "\n")
+
+    # Firing 2: delivered + answered — ships once, with the real final output.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-gate", transcript)
+    assert len(roots()) == 1
+    assert roots()[0].output == {"role": "assistant", "content": "Fertig: 42 Ergebnisse."}
+
+    # Firing 3 (idle): the exported root is final; nothing re-opens or duplicates.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-gate", transcript)
+    assert len(roots()) == 1
 
 
 def test_only_the_turn_root_span_is_marked_as_root(

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -12,6 +12,8 @@ def test_emit_new_turns_from_completed_async_agent_transcript(
     transcript = fixture_transcript_path("async_agent_completed")
     config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
 
+    # First Stop: the trailing turn could still be continued (Stop fires
+    # multiple times within one logical turn), so it is held open.
     emitted = hook_module.emit_new_turns_from_transcript(
         fake_langfuse,
         config,
@@ -19,11 +21,25 @@ def test_emit_new_turns_from_completed_async_agent_transcript(
         transcript,
     )
 
+    assert emitted == 0
+    state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
+    assert next(iter(state.values()))["open_turn_rows"] != []
+
+    # SessionEnd closes it.
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse,
+        config,
+        "session-agent-complete",
+        transcript,
+        flush_deferred_agent_turns=True,
+    )
+
     assert emitted == 1
     assert any(observation.name == "Conversational Turn" for observation in fake_langfuse.observations)
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     assert next(iter(state.values()))["turn_count"] == 1
     assert next(iter(state.values()))["pending_agent_turns"] == []
+    assert next(iter(state.values()))["open_turn_rows"] == []
 
 
 def test_emit_new_turns_defers_async_agent_until_session_end_flush(
@@ -42,11 +58,12 @@ def test_emit_new_turns_defers_async_agent_until_session_end_flush(
         transcript,
     )
 
+    # The trailing turn is held open (its async agent may still notify and
+    # Claude may continue), so it is neither emitted nor deferred yet.
     assert emitted == 0
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
-    pending_agent_turns = next(iter(state.values()))["pending_agent_turns"]
-    assert len(pending_agent_turns) == 1
-    assert pending_agent_turns[0]["pending_tool_use_ids"] == ["toolu_agent_deferred"]
+    assert next(iter(state.values()))["pending_agent_turns"] == []
+    assert next(iter(state.values()))["open_turn_rows"] != []
 
     emitted = hook_module.emit_new_turns_from_transcript(
         fake_langfuse,

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -77,3 +77,27 @@ def test_emit_new_turns_defers_async_agent_until_session_end_flush(
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     assert next(iter(state.values()))["turn_count"] == 1
     assert next(iter(state.values()))["pending_agent_turns"] == []
+
+
+def test_only_the_turn_root_span_is_marked_as_root(
+    hook_module,
+    fixture_transcript_path,
+    fake_langfuse,
+    isolated_hook_state,
+):
+    # The root span sits under a synthetic trace-id carrier, so its exported
+    # parentSpanId never resolves; without the as_root marker the server
+    # creates only a shallow trace and drops trace-level input/output.
+    transcript = fixture_transcript_path("tool_turn")
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-as-root", transcript)
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-as-root", transcript, flush_deferred_agent_turns=True
+    )
+
+    roots = [o for o in fake_langfuse.observations if o.name == "Conversational Turn"]
+    children = [o for o in fake_langfuse.observations if o.name != "Conversational Turn"]
+    assert roots and children
+    assert all(o._otel_span.attributes.get("langfuse.internal.as_root") is True for o in roots)
+    assert all("langfuse.internal.as_root" not in o._otel_span.attributes for o in children)

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -101,3 +101,6 @@ def test_only_the_turn_root_span_is_marked_as_root(
     assert roots and children
     assert all(o._otel_span.attributes.get("langfuse.internal.as_root") is True for o in roots)
     assert all("langfuse.internal.as_root" not in o._otel_span.attributes for o in children)
+    # Children explicitly opt out of the SDK's app-root auto-marking, so the
+    # events view never lists them as root observations.
+    assert all(o._otel_span.attributes.get("langfuse.internal.is_app_root") is False for o in children)

--- a/tests/unit/test_async_agent_deferral.py
+++ b/tests/unit/test_async_agent_deferral.py
@@ -119,7 +119,7 @@ def test_completed_async_agent_turn_is_ready_to_emit(
     # The trailing turn is held open on Stop; SessionEnd closes and emits it.
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state, subagents)
     assert turns == []
-    assert state.open_turn_rows != []
+    assert state.open_turn.get("rows")
 
     turns, state = hook_module.get_new_turns_from_transcript(
         transcript, state, subagents, flush_deferred_agent_turns=True)
@@ -128,7 +128,7 @@ def test_completed_async_agent_turn_is_ready_to_emit(
     assert len(turns) == 1
     assert len(turns_to_emit) == 1
     assert state.pending_agent_turns == []
-    assert state.open_turn_rows == []
+    assert state.open_turn == {}
     result = turns[0].tool_results_by_id["toolu_agent_complete"]
     assert result["final_content"] == "Subagent summary is ready."
 
@@ -148,7 +148,7 @@ def test_uncompleted_async_agent_turn_is_held_open_and_flushed_at_session_end(
     # not deferred: deferral applies to closed turns only.
     assert turns_to_emit == []
     assert state.pending_agent_turns == []
-    assert state.open_turn_rows != []
+    assert state.open_turn.get("rows")
 
     flushed_turns, state = hook_module.get_new_turns_from_transcript(
         transcript,
@@ -164,7 +164,7 @@ def test_uncompleted_async_agent_turn_is_held_open_and_flushed_at_session_end(
 
     assert len(flushed_to_emit) == 1
     assert state.pending_agent_turns == []
-    assert state.open_turn_rows == []
+    assert state.open_turn == {}
 
 
 def test_turn_waiting_on_multiple_agents_resolves_only_after_all_notifications(hook_module):
@@ -317,7 +317,7 @@ def test_mid_turn_notification_does_not_corrupt_the_surrounding_turn(hook_module
     append_jsonl(transcript, launch_turn_rows("toolu_bg"))
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
     assert hook_module.get_turns_to_emit(turns, state) == []
-    assert state.open_turn_rows != []
+    assert state.open_turn.get("rows")
 
     # Hook run 2: turn 2 is mid-flight when the notification lands between
     # two of its assistant messages (the normal real-world shape).
@@ -531,7 +531,7 @@ def test_unresolvable_notification_is_stashed_and_resolved_when_meta_appears(hoo
 
     append_jsonl(transcript, launch_turn_rows("toolu_bg"))
     assert run() == []
-    assert state.open_turn_rows != []
+    assert state.open_turn.get("rows")
 
     # Notification lands alone in the next batch; no meta.json on disk yet.
     append_jsonl(transcript, [
@@ -698,15 +698,17 @@ def test_async_turn_keeps_final_answer_arriving_after_notifications(hook_module,
     assert turn.tool_results_by_id["toolu_bg"]["final_content"] == "Agent result."
 
 
-def test_session_state_round_trips_open_turn_rows(hook_module):
+def test_session_state_round_trips_open_turn(hook_module):
     rows = launch_turn_rows("toolu_bg")
-    state = hook_module.SessionState(open_turn_rows=rows)
+    open_turn = {"user_row_uuid": "user-1", "rows": rows,
+                 "emitted_keys": ["msg-1"], "root_span_id": "a3f9c2d1e5b70468"}
+    state = hook_module.SessionState(open_turn=open_turn)
     global_state: dict[str, Any] = {}
 
     hook_module.update_session_state(global_state, "key", state)
     restored = hook_module.get_session_state(global_state, "key")
 
-    assert restored.open_turn_rows == rows
+    assert restored.open_turn == open_turn
 
 
 def test_stashed_notification_reaches_still_open_turn_at_session_end(hook_module, tmp_path):
@@ -741,4 +743,4 @@ def test_stashed_notification_reaches_still_open_turn_at_session_end(hook_module
     assert flushed[0].user_msg["uuid"] == "user-1"
     assert flushed[0].tool_results_by_id["toolu_bg"]["final_content"] == "Late result."
     assert state.pending_task_notifications == []
-    assert state.open_turn_rows == []
+    assert state.open_turn == {}

--- a/tests/unit/test_async_agent_deferral.py
+++ b/tests/unit/test_async_agent_deferral.py
@@ -116,17 +116,24 @@ def test_completed_async_agent_turn_is_ready_to_emit(
     state = hook_module.SessionState()
     subagents = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
 
+    # The trailing turn is held open on Stop; SessionEnd closes and emits it.
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state, subagents)
-    turns_to_emit = hook_module.get_turns_to_emit(turns, state)
+    assert turns == []
+    assert state.open_turn_rows != []
+
+    turns, state = hook_module.get_new_turns_from_transcript(
+        transcript, state, subagents, flush_deferred_agent_turns=True)
+    turns_to_emit = hook_module.get_turns_to_emit(turns, state, flush_deferred_agent_turns=True)
 
     assert len(turns) == 1
     assert len(turns_to_emit) == 1
     assert state.pending_agent_turns == []
+    assert state.open_turn_rows == []
     result = turns[0].tool_results_by_id["toolu_agent_complete"]
     assert result["final_content"] == "Subagent summary is ready."
 
 
-def test_uncompleted_async_agent_turn_is_deferred_until_flush(
+def test_uncompleted_async_agent_turn_is_held_open_and_flushed_at_session_end(
     hook_module,
     fixture_transcript_path,
 ):
@@ -137,9 +144,11 @@ def test_uncompleted_async_agent_turn_is_deferred_until_flush(
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state, subagents)
     turns_to_emit = hook_module.get_turns_to_emit(turns, state)
 
+    # Held open (its agent may still notify and Claude may continue),
+    # not deferred: deferral applies to closed turns only.
     assert turns_to_emit == []
-    assert len(state.pending_agent_turns) == 1
-    assert state.pending_agent_turns[0]["pending_tool_use_ids"] == ["toolu_agent_deferred"]
+    assert state.pending_agent_turns == []
+    assert state.open_turn_rows != []
 
     flushed_turns, state = hook_module.get_new_turns_from_transcript(
         transcript,
@@ -155,6 +164,7 @@ def test_uncompleted_async_agent_turn_is_deferred_until_flush(
 
     assert len(flushed_to_emit) == 1
     assert state.pending_agent_turns == []
+    assert state.open_turn_rows == []
 
 
 def test_turn_waiting_on_multiple_agents_resolves_only_after_all_notifications(hook_module):
@@ -303,11 +313,11 @@ def test_mid_turn_notification_does_not_corrupt_the_surrounding_turn(hook_module
     transcript = tmp_path / "transcript.jsonl"
     state = hook_module.SessionState()
 
-    # Hook run 1: turn 1 launches an async agent and ends -> deferred.
+    # Hook run 1: turn 1 launches an async agent and ends -> held open.
     append_jsonl(transcript, launch_turn_rows("toolu_bg"))
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
     assert hook_module.get_turns_to_emit(turns, state) == []
-    assert len(state.pending_agent_turns) == 1
+    assert state.open_turn_rows != []
 
     # Hook run 2: turn 2 is mid-flight when the notification lands between
     # two of its assistant messages (the normal real-world shape).
@@ -328,17 +338,22 @@ def test_mid_turn_notification_does_not_corrupt_the_surrounding_turn(hook_module
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
     turns_to_emit = hook_module.get_turns_to_emit(turns, state)
 
+    # Turn 1 is closed by user-2 and emitted complete; the notification that
+    # arrived after user-2 still reaches it. Turn 2 is now the open turn.
     assert state.pending_agent_turns == []
-    assert len(turns_to_emit) == 2
+    assert len(turns_to_emit) == 1
+    closed_turn = turns_to_emit[0]
+    assert closed_turn.user_msg["uuid"] == "user-1"
+    assert [m["message"]["id"] for m in closed_turn.assistant_msgs] == ["msg-1", "msg-2"]
+    assert closed_turn.tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
 
-    resolved_turn, current_turn = turns_to_emit
-    # The deferred turn is rebuilt intact, with the notification result attached.
-    assert resolved_turn.user_msg["uuid"] == "user-1"
-    assert [m["message"]["id"] for m in resolved_turn.assistant_msgs] == ["msg-1", "msg-2"]
-    assert resolved_turn.tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
-    # The current turn keeps ALL of its assistant messages.
-    assert current_turn.user_msg["uuid"] == "user-2"
-    assert [m["message"]["id"] for m in current_turn.assistant_msgs] == ["msg-3", "msg-4"]
+    # SessionEnd closes turn 2 with ALL of its assistant messages.
+    turns, state = hook_module.get_new_turns_from_transcript(
+        transcript, state, flush_deferred_agent_turns=True)
+    flushed = hook_module.get_turns_to_emit(turns, state, flush_deferred_agent_turns=True)
+    assert len(flushed) == 1
+    assert flushed[0].user_msg["uuid"] == "user-2"
+    assert [m["message"]["id"] for m in flushed[0].assistant_msgs] == ["msg-3", "msg-4"]
 
 
 def test_notification_before_first_assistant_row_does_not_drop_the_turn(hook_module, tmp_path):
@@ -363,12 +378,17 @@ def test_notification_before_first_assistant_row_does_not_drop_the_turn(hook_mod
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
     turns_to_emit = hook_module.get_turns_to_emit(turns, state)
 
-    assert len(turns_to_emit) == 2
-    resolved_turn, current_turn = turns_to_emit
-    assert resolved_turn.user_msg["uuid"] == "user-1"
-    assert resolved_turn.tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
-    assert current_turn.user_msg["uuid"] == "user-2"
-    assert [m["message"]["id"] for m in current_turn.assistant_msgs] == ["msg-3"]
+    assert len(turns_to_emit) == 1
+    closed_turn = turns_to_emit[0]
+    assert closed_turn.user_msg["uuid"] == "user-1"
+    assert closed_turn.tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
+
+    turns, state = hook_module.get_new_turns_from_transcript(
+        transcript, state, flush_deferred_agent_turns=True)
+    flushed = hook_module.get_turns_to_emit(turns, state, flush_deferred_agent_turns=True)
+    assert len(flushed) == 1
+    assert flushed[0].user_msg["uuid"] == "user-2"
+    assert [m["message"]["id"] for m in flushed[0].assistant_msgs] == ["msg-3"]
 
 
 def sync_agent_turn_rows(tool_use_id: str = "toolu_sync", result_text: str = "Here is the final research report.") -> list[dict[str, Any]]:
@@ -511,7 +531,7 @@ def test_unresolvable_notification_is_stashed_and_resolved_when_meta_appears(hoo
 
     append_jsonl(transcript, launch_turn_rows("toolu_bg"))
     assert run() == []
-    assert len(state.pending_agent_turns) == 1
+    assert state.open_turn_rows != []
 
     # Notification lands alone in the next batch; no meta.json on disk yet.
     append_jsonl(transcript, [
@@ -520,22 +540,29 @@ def test_unresolvable_notification_is_stashed_and_resolved_when_meta_appears(hoo
     assert run() == []
     assert len(state.pending_task_notifications) == 1
 
-    # meta.json appears late; the stashed notification resolves on this run.
+    # meta.json appears late; user-2 closes turn 1, which defers because its
+    # agent still has no final result.
     write_subagent_meta(transcript, "agent-late", "toolu_bg")
     append_jsonl(transcript, [
         make_user_row("user-2", "Next question.", "2026-01-01T00:02:00.000Z"),
         make_assistant_row("assistant-3", "msg-3",
                            [{"type": "text", "text": "Answer."}], "2026-01-01T00:02:01.000Z"),
     ])
-    emitted = run()
+    assert run() == []
+    assert len(state.pending_agent_turns) == 1
 
-    assert [t.user_msg["uuid"] for t in emitted] == ["user-1", "user-2"]
+    # Next run: the stashed notification now matches the deferred turn.
+    emitted = run()
+    assert [t.user_msg["uuid"] for t in emitted] == ["user-1"]
     assert emitted[0].tool_results_by_id["toolu_bg"]["final_content"] == "Late result."
     assert state.pending_agent_turns == []
     assert state.pending_task_notifications == []
 
+    flushed = run(flush=True)
+    assert [t.user_msg["uuid"] for t in flushed] == ["user-2"]
 
-def test_stashed_notification_without_matching_deferred_turn_is_dropped(hook_module):
+
+def test_stashed_notification_without_matching_deferred_turn_is_kept(hook_module):
     state = hook_module.SessionState(
         pending_task_notifications=[
             make_notification_row("n1", "toolu_gone", "Result", "2026-01-01T00:01:00.000Z"),
@@ -544,11 +571,12 @@ def test_stashed_notification_without_matching_deferred_turn_is_dropped(hook_mod
 
     resolved, remaining = hook_module.resolve_deferred_agent_turns([], state)
 
-    # Resolvable but nothing waits for it (turn already emitted): drop it
-    # instead of re-stashing forever.
+    # Resolvable but nothing waits for it yet: the owning turn may still be
+    # open and only defer once a user row closes it, so keep the entry (the
+    # stash is size-capped and cleared at session end).
     assert resolved == []
     assert remaining == []
-    assert state.pending_task_notifications == []
+    assert len(state.pending_task_notifications) == 1
 
 
 def test_unresolved_notifications_are_dropped_at_session_end_flush(hook_module, tmp_path):
@@ -596,3 +624,121 @@ def test_session_state_round_trips_stashed_notifications(hook_module):
     restored = hook_module.get_session_state(global_state, "key")
 
     assert restored.pending_task_notifications == [notification]
+
+
+def test_turn_continuation_across_stop_firings_is_not_lost(hook_module, tmp_path):
+    """Regression (LFE-10747): Stop can fire multiple times within one logical
+    turn (blocking hooks); continuation rows arriving in the next batch used
+    to be dropped and the turn emitted truncated."""
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, [
+        make_user_row("user-1", "Question.", "2026-01-01T00:00:00.000Z"),
+        make_assistant_row("assistant-1", "msg-1",
+                           [{"type": "text", "text": "Part one."}], "2026-01-01T00:00:01.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    # Stop #2: the rest of the SAME logical turn.
+    append_jsonl(transcript, [
+        make_assistant_row("assistant-2", "msg-2",
+                           [{"type": "text", "text": "Part two (continuation)."}], "2026-01-01T00:00:02.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    # A new user row closes turn 1 -> emitted with BOTH parts.
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Next.", "2026-01-01T00:01:00.000Z"),
+        make_assistant_row("assistant-3", "msg-3",
+                           [{"type": "text", "text": "Second answer."}], "2026-01-01T00:01:01.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    assert emitted[0].user_msg["uuid"] == "user-1"
+    assert [m["message"]["id"] for m in emitted[0].assistant_msgs] == ["msg-1", "msg-2"]
+
+
+def test_async_turn_keeps_final_answer_arriving_after_notifications(hook_module, tmp_path):
+    """Regression (LFE-10747): an async-agent turn spans several Stop firings
+    (launch -> notification -> continuation); the post-notification assistant
+    rows carry the final answer and used to be dropped."""
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    def run(flush=False):
+        turns, _ = hook_module.get_new_turns_from_transcript(
+            transcript, state, flush_deferred_agent_turns=flush)
+        return hook_module.get_turns_to_emit(turns, state, flush_deferred_agent_turns=flush)
+
+    # Stop #1: launch turn ("agents are running...").
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    assert run() == []
+
+    # Stop #2: notification plus Claude's continuation with the real answer.
+    append_jsonl(transcript, [
+        make_notification_row("notif-1", "toolu_bg", "Agent result.", "2026-01-01T00:01:00.000Z"),
+        make_assistant_row("assistant-3", "msg-3",
+                           [{"type": "text", "text": "Final answer based on the agent result."}],
+                           "2026-01-01T00:01:01.000Z"),
+    ])
+    assert run() == []
+
+    flushed = run(flush=True)
+
+    assert len(flushed) == 1
+    turn = flushed[0]
+    assert turn.user_msg["uuid"] == "user-1"
+    # launch message, "running" message, AND the post-notification answer
+    assert [m["message"]["id"] for m in turn.assistant_msgs] == ["msg-1", "msg-2", "msg-3"]
+    assert turn.tool_results_by_id["toolu_bg"]["final_content"] == "Agent result."
+
+
+def test_session_state_round_trips_open_turn_rows(hook_module):
+    rows = launch_turn_rows("toolu_bg")
+    state = hook_module.SessionState(open_turn_rows=rows)
+    global_state: dict[str, Any] = {}
+
+    hook_module.update_session_state(global_state, "key", state)
+    restored = hook_module.get_session_state(global_state, "key")
+
+    assert restored.open_turn_rows == rows
+
+
+def test_stashed_notification_reaches_still_open_turn_at_session_end(hook_module, tmp_path):
+    """Regression: if no further user turn ever closes the launch turn, the
+    stashed notification must still attach to it during the SessionEnd flush
+    instead of being discarded alongside an incomplete turn."""
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    def run(flush=False):
+        sub_map = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
+        turns, _ = hook_module.get_new_turns_from_transcript(
+            transcript, state, sub_map, flush_deferred_agent_turns=flush)
+        return hook_module.get_turns_to_emit(turns, state, flush_deferred_agent_turns=flush)
+
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    assert run() == []
+
+    # task-id-only notification, meta.json not on disk yet -> stashed
+    append_jsonl(transcript, [
+        make_task_id_notification_row("n1", "agent-late", "Late result.", "2026-01-01T00:01:00.000Z"),
+    ])
+    assert run() == []
+    assert len(state.pending_task_notifications) == 1
+
+    # meta.json appears, but the user never writes again: SessionEnd must
+    # deliver the stashed result to the still-open turn.
+    write_subagent_meta(transcript, "agent-late", "toolu_bg")
+    flushed = run(flush=True)
+
+    assert len(flushed) == 1
+    assert flushed[0].user_msg["uuid"] == "user-1"
+    assert flushed[0].tool_results_by_id["toolu_bg"]["final_content"] == "Late result."
+    assert state.pending_task_notifications == []
+    assert state.open_turn_rows == []

--- a/tests/unit/test_emission_gate.py
+++ b/tests/unit/test_emission_gate.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+NOTIFICATION = (
+    "<task-notification>\n<task-id>t1</task-id>\n"
+    "<tool-use-id>toolu_X</tool-use-id>\n<result>done</result>\n</task-notification>"
+)
+
+
+def test_queued_notification_counts_as_undelivered(hook_module):
+    rows = [
+        {"type": "queue-operation", "operation": "enqueue", "content": NOTIFICATION},
+    ]
+    assert hook_module.get_undelivered_queued_notification_ids(rows) == ["toolu_X"]
+
+
+def test_delivery_clears_the_queued_notification(hook_module):
+    rows = [
+        {"type": "queue-operation", "operation": "enqueue", "content": NOTIFICATION},
+        {"type": "user", "origin": {"kind": "task-notification"},
+         "message": {"role": "user", "content": NOTIFICATION}},
+    ]
+    assert hook_module.get_undelivered_queued_notification_ids(rows) == []
+
+
+def test_rows_without_notifications_pass_the_gate(hook_module):
+    rows = [
+        {"type": "user", "message": {"role": "user", "content": "hallo"}},
+        {"type": "queue-operation", "operation": "remove", "content": None},
+    ]
+    assert hook_module.get_undelivered_queued_notification_ids(rows) == []

--- a/tests/unit/test_remote_parent.py
+++ b/tests/unit/test_remote_parent.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import hashlib
+
+
+def expected_trace_id_int(session_id: str, user_row_uuid: str) -> int:
+    seed = f"{session_id}:{user_row_uuid}"
+    return int(hashlib.sha256(seed.encode("utf-8")).digest()[:16].hex(), 16)
+
+
+def test_remote_parent_pins_deterministic_trace_id(hook_module, fake_langfuse):
+    parent = hook_module.remote_parent(fake_langfuse, "sess-1", "row-uuid-1")
+
+    context = parent.get_span_context()
+    assert context.trace_id == expected_trace_id_int("sess-1", "row-uuid-1")
+    assert context.span_id != 0
+
+
+def test_remote_parent_without_root_span_id_varies_phantom_span_id(hook_module, fake_langfuse):
+    contexts = [
+        hook_module.remote_parent(fake_langfuse, "sess-1", "row-uuid-1").get_span_context()
+        for _ in range(2)
+    ]
+    # Same turn, same trace id -- but the phantom span id is random because
+    # children must become trace roots, not siblings under a stable parent.
+    assert contexts[0].trace_id == contexts[1].trace_id
+
+
+def test_remote_parent_nests_under_stored_root_span_id(hook_module, fake_langfuse):
+    root_span_id = "00f067aa0ba902b7"
+
+    parent = hook_module.remote_parent(
+        fake_langfuse, "sess-1", "row-uuid-1", root_span_id=root_span_id
+    )
+
+    context = parent.get_span_context()
+    assert context.span_id == int(root_span_id, 16)
+    assert context.trace_id == expected_trace_id_int("sess-1", "row-uuid-1")
+
+
+def test_remote_parent_requires_user_row_uuid(hook_module, fake_langfuse):
+    assert hook_module.remote_parent(fake_langfuse, "sess-1", None) is None
+    assert hook_module.remote_parent(fake_langfuse, "sess-1", "") is None

--- a/tests/unit/test_timestamps.py
+++ b/tests/unit/test_timestamps.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def test_to_otel_nanoseconds_keeps_the_exact_millisecond(hook_module):
+    # Regression: int(ts.timestamp() * 1e9) truncates values that float math
+    # places just below the millisecond (…58599999… -> .585 instead of .586);
+    # observed live as a systematic -1ms drift on emitted span times.
+    ts = datetime(2026, 7, 20, 17, 6, 8, 586000, tzinfo=timezone.utc)
+
+    ns = hook_module.to_otel_nanoseconds(ts)
+
+    assert ns % 1_000_000 == 0
+    assert (ns // 1_000_000) % 1000 == 586

--- a/tests/unit/test_transcript_reader.py
+++ b/tests/unit/test_transcript_reader.py
@@ -55,3 +55,49 @@ def test_read_new_jsonl_restarts_when_file_shrinks(hook_module, tmp_path):
     rows, state = hook_module.read_new_jsonl(transcript, state)
     assert rows == [second]
     assert state.offset == transcript.stat().st_size
+
+
+def test_rotation_clears_persisted_turn_state_and_avoids_duplicate_turns(hook_module, tmp_path):
+    """Regression (LFE-10752): when the transcript shrinks (rotation), the
+    offset restarts at 0 but held turn state used to survive — re-reading the
+    file then emitted the held turn a second time."""
+    import json
+
+    transcript = tmp_path / "transcript.jsonl"
+
+    def turn_rows(name: str) -> list[dict]:
+        return [
+            {"type": "user", "timestamp": "2026-01-01T00:00:00.000Z", "uuid": f"{name}-user",
+             "message": {"role": "user", "content": "Question."}},
+            {"type": "assistant", "timestamp": "2026-01-01T00:00:01.000Z", "uuid": f"{name}-assistant",
+             "message": {"id": f"{name}-msg", "role": "assistant", "model": "m",
+                         "content": [{"type": "text", "text": "Answer."}]}},
+        ]
+
+    def write(rows: list[dict]) -> None:
+        transcript.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    emitted = []
+    state = hook_module.SessionState()
+
+    # Run 1: two separate turns; turn A closes, turn B is trailing -> held open.
+    write(turn_rows("turn-a") + turn_rows("turn-b"))
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted += hook_module.get_turns_to_emit(turns, state)
+    assert [t.user_msg["uuid"] for t in emitted] == ["turn-a-user"]
+    assert state.open_turn_rows != []
+    assert state.offset > 0
+
+    # Rotation: the file is replaced by a SHORTER one that still contains the
+    # held turn's rows (rewrite-after-truncate shape).
+    write(turn_rows("turn-b"))
+    turns, state = hook_module.get_new_turns_from_transcript(
+        transcript, state, flush_deferred_agent_turns=True)
+    emitted += hook_module.get_turns_to_emit(turns, state, flush_deferred_agent_turns=True)
+
+    # Across BOTH runs every turn is emitted exactly once — the held copy of
+    # turn B must not be emitted alongside the re-read one.
+    assert [t.user_msg["uuid"] for t in emitted] == ["turn-a-user", "turn-b-user"]
+    assert state.pending_agent_turns == []
+    assert state.pending_task_notifications == []
+    assert state.open_turn_rows == []

--- a/tests/unit/test_transcript_reader.py
+++ b/tests/unit/test_transcript_reader.py
@@ -85,7 +85,7 @@ def test_rotation_clears_persisted_turn_state_and_avoids_duplicate_turns(hook_mo
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
     emitted += hook_module.get_turns_to_emit(turns, state)
     assert [t.user_msg["uuid"] for t in emitted] == ["turn-a-user"]
-    assert state.open_turn_rows != []
+    assert state.open_turn.get("rows")
     assert state.offset > 0
 
     # Rotation: the file is replaced by a SHORTER one that still contains the
@@ -100,4 +100,4 @@ def test_rotation_clears_persisted_turn_state_and_avoids_duplicate_turns(hook_mo
     assert [t.user_msg["uuid"] for t in emitted] == ["turn-a-user", "turn-b-user"]
     assert state.pending_agent_turns == []
     assert state.pending_task_notifications == []
-    assert state.open_turn_rows == []
+    assert state.open_turn == {}


### PR DESCRIPTION
## Summary

Closes LFE-10747. Closes LFE-10752. Addresses point 1b of #5.

`Stop` fires multiple times within one logical turn, while turn assembly was
stateless per hook run: the trailing turn was emitted (truncated) at every
Stop, and continuation rows arriving in the next batch (task notifications,
assistant messages) were silently dropped — async-agent turns lost their
final answer.

This PR fixes that in two layers:

**1. Open turns survive Stop firings**

- the trailing turn's rows are held in session state and re-attached to the
  next batch; a new user row (or SessionEnd) closes it
- task notifications are delivered to turns closed earlier in the same batch;
  unmatched ones are stashed and replayed once at session end
- persisted turn state is cleared on transcript rotation (LFE-10752)

**2. Open turns emit incrementally, per Stop**

Instead of staying invisible until it closes, the open turn's trace appears
at the first Stop and grows:

- every firing emits the turn's *ready* observations — those whose emitted
  form can no longer change (tool has its result, generation complete,
  subagent finished); an `EmissionCursor` plus per-turn progress in session
  state prevents duplicates across firings
- the root span is exported provisionally (OTel only exports ended spans) and
  corrected via `span-update`/`trace-create` events on the batch ingestion
  API; updates are queued under the state lock and POSTed after release, and
  idle firings send nothing
- continuation firings attach children to the already-exported root via a
  remote-parent carrier (deterministic trace id from `session_id:user_row_uuid`,
  span id = the stored root span id)

**Composition with #23 (`CC_LANGFUSE_TRACE_SEED`),** which independently
introduced forced trace ids: with a seed set, the root adopts the
`seed:turn_number`-derived id; continuation firings always reuse the trace id
stored at root creation, so a turn never switches trace mid-flight.
**Note for review:** 4 assertions in
`tests/integration/test_deterministic_trace_ids.py` were adapted
(`emitted == 2` → `1`) — the trailing turn no longer counts as emitted while
open (its root already exists provisionally); all trace-id and fallback
assertions are unchanged.

## Testing

- 78 tests green (incl. new coverage for cursor gating, idle-firing silence,
  remote-parent nesting, seeded resume; #23's suites keep passing)
- live-verified in Langfuse Cloud (`testing_ccode`): async-agent turn across
  multiple Stop firings — trace appears at the first Stop, grows without
  duplicate roots, final output lands via span-update (verified through the
  public API; events-view caveat → LFE-11026)