### PR TITLE
fix(hook): tag skills invoked via slash commands

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1068,27 +1068,61 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
     )
 
 # ---- Trace naming and tags ----
-def collect_skill_tags(turn: Turn) -> List[str]:
-    """Return 'skill:<name>' tags for every skill used in the turn.
+def add_skill_tags_from_rows(rows: List[Dict[str, Any]], names: List[str], prefix: str) -> None:
+    """Collect '<prefix><name>' tags for every skill trail in the rows.
 
     Skills leave two different transcript trails: a tool_use block named
     "Skill" when Claude invokes the skill itself, and a top-level
     attributionSkill field on assistant rows when the user invokes it as a
     slash command (which never produces a Skill tool_use block).
     """
-    names: List[str] = []
-
     def add_skill(skill: Any) -> None:
-        if isinstance(skill, str) and skill and f"skill:{skill}" not in names:
-            names.append(f"skill:{skill}")
+        if isinstance(skill, str) and skill and f"{prefix}{skill}" not in names:
+            names.append(f"{prefix}{skill}")
 
-    for assistant_message in turn.assistant_msgs:
-        add_skill(assistant_message.get("attributionSkill"))
-        for tool_use in get_tool_use_blocks(get_content_from_row(assistant_message)):
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        add_skill(row.get("attributionSkill"))
+        for tool_use in get_tool_use_blocks(get_content_from_row(row)):
             if tool_use.get("name") != "Skill":
                 continue
             tool_input = tool_use.get("input")
             add_skill(tool_input.get("skill") if isinstance(tool_input, dict) else None)
+
+
+def collect_skill_tags(turn: Turn) -> List[str]:
+    """Return 'skill:<name>' tags for every skill used in the turn itself."""
+    names: List[str] = []
+    add_skill_tags_from_rows(turn.assistant_msgs, names, "skill:")
+    return names
+
+
+def collect_subagent_skill_tags(
+    turn: Turn,
+    subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> List[str]:
+    """Return 'subagent-skill:<name>' tags for skills used inside the
+    subagent transcripts launched by this turn.
+
+    Kept in a separate tag namespace so 'skill:' keeps meaning "ran in the
+    main conversation" and both dimensions stay filterable independently.
+    """
+    if not subagent_transcripts_by_tool_use_id:
+        return []
+    names: List[str] = []
+    for assistant_message in turn.assistant_msgs:
+        for tool_use in get_tool_use_blocks(get_content_from_row(assistant_message)):
+            tool_use_id = str(tool_use.get("id") or "")
+            subagent = subagent_transcripts_by_tool_use_id.get(tool_use_id) if tool_use_id else None
+            if not isinstance(subagent, dict):
+                continue
+            path = subagent.get("path")
+            if not isinstance(path, Path):
+                continue
+            rows = read_subagent_jsonl(path)
+            if rows:
+                add_skill_tags_from_rows(rows, names, "subagent-skill:")
     return names
 
 def short_session_label(session_id: str, max_len: int = 12) -> str:
@@ -1104,10 +1138,14 @@ def short_session_label(session_id: str, max_len: int = 12) -> str:
 def trace_display_name(session_id: str, turn_num: int) -> str:
     return f"Claude Code - Turn {turn_num} ({short_session_label(session_id)})"
 
-def get_trace_tags(turn: Turn) -> List[str]:
+def get_trace_tags(
+    turn: Turn,
+    subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> List[str]:
     tags = ["claude-code"]
     if SKILL_TAGS:
         tags += collect_skill_tags(turn)
+        tags += collect_subagent_skill_tags(turn, subagent_transcripts_by_tool_use_id)
     return tags
 
 # ---- Generation payloads ----
@@ -1708,7 +1746,7 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
     last_assistant_ts = parse_timestamp(last_assistant)
     turn_end_ts = get_turn_end_timestamp(turn)
     trace_metadata = build_trace_metadata(session_id, turn_num, turn, transcript_path, user_text_meta)
-    tags = get_trace_tags(turn)
+    tags = get_trace_tags(turn, subagent_transcripts_by_tool_use_id)
 
     trace_name = trace_display_name(session_id, turn_num)
     root_observation_name = "Conversational Turn"

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1069,16 +1069,26 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
 
 # ---- Trace naming and tags ----
 def collect_skill_tags(turn: Turn) -> List[str]:
-    """Return 'skill:<name>' tags for every Skill tool invocation in the turn."""
+    """Return 'skill:<name>' tags for every skill used in the turn.
+
+    Skills leave two different transcript trails: a tool_use block named
+    "Skill" when Claude invokes the skill itself, and a top-level
+    attributionSkill field on assistant rows when the user invokes it as a
+    slash command (which never produces a Skill tool_use block).
+    """
     names: List[str] = []
+
+    def add_skill(skill: Any) -> None:
+        if isinstance(skill, str) and skill and f"skill:{skill}" not in names:
+            names.append(f"skill:{skill}")
+
     for assistant_message in turn.assistant_msgs:
+        add_skill(assistant_message.get("attributionSkill"))
         for tool_use in get_tool_use_blocks(get_content_from_row(assistant_message)):
             if tool_use.get("name") != "Skill":
                 continue
             tool_input = tool_use.get("input")
-            skill = tool_input.get("skill") if isinstance(tool_input, dict) else None
-            if isinstance(skill, str) and skill and f"skill:{skill}" not in names:
-                names.append(f"skill:{skill}")
+            add_skill(tool_input.get("skill") if isinstance(tool_input, dict) else None)
     return names
 
 def short_session_label(session_id: str, max_len: int = 12) -> str:

--- a/tests/unit/test_skill_tags.py
+++ b/tests/unit/test_skill_tags.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def make_user_row(text: str) -> dict[str, Any]:
+    return {
+        "type": "user",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "uuid": "user-1",
+        "message": {"role": "user", "content": text},
+    }
+
+
+def make_skill_tool_use_row(skill: str) -> dict[str, Any]:
+    """Invocation path 1: Claude calls the Skill tool itself."""
+    return {
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:01.000Z",
+        "uuid": "assistant-tool",
+        "message": {
+            "id": "msg-tool",
+            "role": "assistant",
+            "model": "claude-test",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_skill",
+                    "name": "Skill",
+                    "input": {"skill": skill, "args": "do the thing"},
+                }
+            ],
+        },
+    }
+
+
+def make_attributed_assistant_row(skill: str, uuid: str = "assistant-attr") -> dict[str, Any]:
+    """Invocation path 2: slash command — the harness expands the skill and
+    marks the assistant rows with a top-level attributionSkill field."""
+    return {
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:02.000Z",
+        "uuid": uuid,
+        "attributionSkill": skill,
+        "message": {
+            "id": f"msg-{uuid}",
+            "role": "assistant",
+            "model": "claude-test",
+            "content": [{"type": "text", "text": "Greetings, esteemed colleague."}],
+        },
+    }
+
+
+def collect_tags(hook_module, rows: list[dict[str, Any]]) -> list[str]:
+    turns = hook_module.build_turns(rows)
+    assert len(turns) == 1
+    return hook_module.collect_skill_tags(turns[0])
+
+
+def test_skill_invoked_via_tool_call_is_tagged(hook_module):
+    rows = [
+        make_user_row("What are the current model ids?"),
+        make_skill_tool_use_row("claude-api"),
+    ]
+
+    assert collect_tags(hook_module, rows) == ["skill:claude-api"]
+
+
+def test_skill_invoked_via_slash_command_is_tagged(hook_module):
+    # Slash commands never produce a Skill tool_use block; the skill shows up
+    # only as attributionSkill on the assistant rows (GitHub #15).
+    rows = [
+        make_user_row("<command-message>greeting-style</command-message>\n<command-name>/greeting-style</command-name>"),
+        make_attributed_assistant_row("greeting-style"),
+    ]
+
+    assert collect_tags(hook_module, rows) == ["skill:greeting-style"]
+
+
+def test_skills_from_both_invocation_paths_are_tagged(hook_module):
+    rows = [
+        make_user_row("Do two things."),
+        make_skill_tool_use_row("claude-api"),
+        make_attributed_assistant_row("greeting-style"),
+    ]
+
+    assert sorted(collect_tags(hook_module, rows)) == [
+        "skill:claude-api",
+        "skill:greeting-style",
+    ]
+
+
+def test_same_skill_from_both_paths_is_tagged_once(hook_module):
+    rows = [
+        make_user_row("Do one thing."),
+        make_skill_tool_use_row("greeting-style"),
+        make_attributed_assistant_row("greeting-style"),
+    ]
+
+    assert collect_tags(hook_module, rows) == ["skill:greeting-style"]

--- a/tests/unit/test_skill_tags.py
+++ b/tests/unit/test_skill_tags.py
@@ -98,3 +98,77 @@ def test_same_skill_from_both_paths_is_tagged_once(hook_module):
     ]
 
     assert collect_tags(hook_module, rows) == ["skill:greeting-style"]
+
+
+def make_agent_launch_row(tool_use_id: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:01.000Z",
+        "uuid": "assistant-agent",
+        "message": {
+            "id": "msg-agent",
+            "role": "assistant",
+            "model": "claude-test",
+            "content": [
+                {"type": "tool_use", "id": tool_use_id, "name": "Agent",
+                 "input": {"description": "Research", "prompt": "Go research"}}
+            ],
+        },
+    }
+
+
+def write_subagent_transcript(tmp_path, agent_id: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    import json as _json
+    path = tmp_path / f"agent-{agent_id}.jsonl"
+    path.write_text("\n".join(_json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return {"path": path, "agent_id": agent_id, "agent_type": "general-purpose", "description": "bg"}
+
+
+def test_skills_used_inside_subagents_are_tagged_with_own_prefix(hook_module, tmp_path):
+    subagent_rows = [
+        make_user_row("Subagent prompt."),
+        make_attributed_assistant_row("deep-research", uuid="sub-assistant-1"),
+        make_skill_tool_use_row("claude-api"),
+    ]
+    sub_map = {"toolu_agent_1": write_subagent_transcript(tmp_path, "a1", subagent_rows)}
+    turns = hook_module.build_turns([
+        make_user_row("Run an agent."),
+        make_agent_launch_row("toolu_agent_1"),
+    ])
+
+    tags = hook_module.collect_subagent_skill_tags(turns[0], sub_map)
+
+    assert sorted(tags) == ["subagent-skill:claude-api", "subagent-skill:deep-research"]
+
+
+def test_subagent_skills_do_not_leak_into_main_skill_namespace(hook_module, tmp_path):
+    sub_map = {"toolu_agent_1": write_subagent_transcript(tmp_path, "a1", [
+        make_attributed_assistant_row("deep-research", uuid="sub-assistant-1"),
+    ])}
+    turns = hook_module.build_turns([
+        make_user_row("Run an agent."),
+        make_agent_launch_row("toolu_agent_1"),
+    ])
+
+    assert hook_module.collect_skill_tags(turns[0]) == []
+    assert hook_module.get_trace_tags(turns[0], sub_map) == [
+        "claude-code",
+        "subagent-skill:deep-research",
+    ]
+
+
+def test_same_skill_across_two_subagents_is_tagged_once(hook_module, tmp_path):
+    row = make_attributed_assistant_row("deep-research", uuid="sub-assistant-1")
+    sub_map = {
+        "toolu_agent_1": write_subagent_transcript(tmp_path, "a1", [row]),
+        "toolu_agent_2": write_subagent_transcript(tmp_path, "a2", [row]),
+    }
+    launch = make_agent_launch_row("toolu_agent_1")
+    launch2 = make_agent_launch_row("toolu_agent_2")
+    launch2["uuid"] = "assistant-agent-2"
+    launch2["message"] = dict(launch2["message"], id="msg-agent-2")
+    turns = hook_module.build_turns([make_user_row("Run two agents."), launch, launch2])
+
+    assert hook_module.collect_subagent_skill_tags(turns[0], sub_map) == [
+        "subagent-skill:deep-research",
+    ]


### PR DESCRIPTION
## Summary

Closes LFE-10759. Fixes #15.

Skills leave two transcript trails: a `Skill` tool_use block when Claude
invokes the skill itself, and a top-level `attributionSkill` field on the
assistant rows when the user invokes it as a slash command, which never
produces a tool_use block. `collect_skill_tags` only read the first trail,
so slash-command skill runs shipped without their `skill:<name>` tag and
were invisible to tag filtering in Langfuse.

This PR collects both trails, deduped (same skill via both paths tags once).
This PR makes sure to also collect skill tags from subagent JSONL files. 

## Testing

- added 4 new tests in `tests/unit/test_skill_tags.py`
  covering both invocation paths, both combined, and dedup
- Reproduced with a fresh transcript (Claude Code 2.1.201): a skill invoked
  via `/slash-command` produces `attributionSkill` rows and zero `Skill`
  tool_use blocks
- Live-verified in Langfuse with the same transcript: before
  `tags=['claude-code']`, after `tags=['claude-code', 'skill:greeting-style']`