### PR TITLE
Fix Claude Desktop transcript collection

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -221,6 +221,31 @@ def extract_session_id_and_transcript_path(payload: Dict[str, Any]) -> Tuple[Opt
 
     return session_id, transcript_path
 
+def resolve_transcript_path(session_id: str, transcript_path: Path, payload: Dict[str, Any]) -> Path:
+    """Recover from Claude Desktop emitting a non-existent, home-scoped transcript path."""
+    if transcript_path.exists():
+        return transcript_path
+
+    projects_dir = Path.home() / ".claude" / "projects"
+    candidates = list(projects_dir.glob(f"*/{session_id}.jsonl"))
+    if not candidates:
+        return transcript_path
+
+    cwd_raw = payload.get("cwd")
+    if isinstance(cwd_raw, str) and cwd_raw:
+        encoded_cwd = cwd_raw.replace("/", "-").replace("_", "-")
+        cwd_matches = [p for p in candidates if p.parent.name == encoded_cwd]
+        if len(cwd_matches) == 1:
+            debug(f"Recovered transcript path from cwd: {cwd_matches[0]}")
+            return cwd_matches[0].resolve()
+
+    if len(candidates) == 1:
+        debug(f"Recovered unique transcript path: {candidates[0]}")
+        return candidates[0].resolve()
+
+    debug(f"Transcript recovery was ambiguous for session {session_id}: {len(candidates)} candidates")
+    return transcript_path
+
 # ----------------- Transcript parsing helpers -----------------
 def get_content_from_row(row: Dict[str, Any]) -> Any:
     if not isinstance(row, dict):
@@ -812,6 +837,41 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
         trace_span.update(output={"role": "assistant", "content": final_assistant_text})
         trace_span.end(end_time=_to_ns(turn_end_ts or last_assistant_ts or user_ts))
 
+def process_transcript(langfuse: Langfuse, state: Dict[str, Any], session_id: str,
+                       transcript_path: Path, user_id: Optional[str]) -> int:
+    """Upload only the unread portion of one main-agent or subagent transcript."""
+    key = state_key(session_id, str(transcript_path))
+    ss = load_session_state(state, key)
+    msgs, ss = read_new_jsonl(transcript_path, ss)
+    if not msgs:
+        write_session_state(state, key, ss)
+        return 0
+
+    turns = build_turns(msgs)
+    emitted = 0
+    for turn in turns:
+        emitted += 1
+        turn_num = ss.turn_count + emitted
+        try:
+            emit_turn(langfuse, session_id, turn_num, turn, transcript_path, user_id=user_id)
+        except Exception as e:
+            info(f"emit_turn failed: {type(e).__name__}: {e}")
+
+    ss.turn_count += emitted
+    write_session_state(state, key, ss)
+    return emitted
+
+def subagent_transcripts(transcript_path: Path, parent_session_id: str) -> List[Tuple[str, Path]]:
+    """Return Claude Desktop subagent files that are not exposed as usable hook paths."""
+    root = transcript_path.parent / parent_session_id / "subagents"
+    if not root.is_dir():
+        return []
+    out: List[Tuple[str, Path]] = []
+    for path in sorted(root.glob("**/agent-*.jsonl")):
+        agent_id = path.stem
+        out.append((f"{parent_session_id}:{agent_id}", path.resolve()))
+    return out
+
 # ----------------- Main -----------------
 def main() -> int:
     start = time.time()
@@ -833,6 +893,8 @@ def main() -> int:
         debug("Missing session_id or transcript_path from hook payload; exiting.")
         return 0
 
+    transcript_path = resolve_transcript_path(session_id, transcript_path, payload)
+
     if not transcript_path.exists():
         debug(f"Transcript path does not exist: {transcript_path}")
         return 0
@@ -846,40 +908,22 @@ def main() -> int:
     try:
         with FileLock(LOCK_FILE):
             state = load_state()
-            key = state_key(session_id, str(transcript_path))
-            ss = load_session_state(state, key)
-
-            msgs, ss = read_new_jsonl(transcript_path, ss)
-            if not msgs:
-                write_session_state(state, key, ss)
-                save_state(state)
-                return 0
-
-            turns = build_turns(msgs)
-            if not turns:
-                write_session_state(state, key, ss)
-                save_state(state)
-                return 0
-
-            # emit turns
-            emitted = 0
-            for t in turns:
-                emitted += 1
-                turn_num = ss.turn_count + emitted
-                try:
-                    emit_turn(langfuse, session_id, turn_num, t, transcript_path, user_id=user_id)
-                except Exception as e:
-                    # Log at INFO so SDK incompatibilities (and other emit failures)
-                    # are visible without needing CC_LANGFUSE_DEBUG=true.
-                    info(f"emit_turn failed: {type(e).__name__}: {e}")
-                    # continue emitting other turns
-
-            ss.turn_count += emitted
-            write_session_state(state, key, ss)
+            emitted = process_transcript(langfuse, state, session_id, transcript_path, user_id)
+            subagent_emitted = 0
+            for child_session_id, child_path in subagent_transcripts(transcript_path, session_id):
+                subagent_emitted += process_transcript(
+                    langfuse, state, child_session_id, child_path, user_id
+                )
+                # Desktop workflows can create hundreds of agents. Flush after
+                # every file so the bounded SDK queue cannot silently drop spans.
+                langfuse.flush()
             save_state(state)
 
         dur = time.time() - start
-        info(f"Processed {emitted} turns in {dur:.2f}s (session={session_id})")
+        info(
+            f"Processed {emitted} main turns and {subagent_emitted} subagent turns "
+            f"in {dur:.2f}s (session={session_id})"
+        )
         return 0
 
     except TimeoutError as e:

--- a/tests/test_desktop_transcripts.py
+++ b/tests/test_desktop_transcripts.py
@@ -1,0 +1,72 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+HOOK_PATH = Path(__file__).parents[1] / "hooks" / "langfuse_hook.py"
+SPEC = importlib.util.spec_from_file_location("langfuse_hook", HOOK_PATH)
+assert SPEC and SPEC.loader
+HOOK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HOOK)
+
+
+class DesktopTranscriptTests(unittest.TestCase):
+    def test_recovers_desktop_home_scoped_path_using_cwd(self):
+        with tempfile.TemporaryDirectory() as home:
+            projects = Path(home) / ".claude" / "projects"
+            cwd = "/Users/example/work/project"
+            session_id = "session-123"
+            actual = projects / "-Users-example-work-project" / f"{session_id}.jsonl"
+            actual.parent.mkdir(parents=True)
+            actual.touch()
+            broken = projects / "-Users-example" / f"{session_id}.jsonl"
+
+            with patch.object(HOOK.Path, "home", return_value=Path(home)):
+                resolved = HOOK.resolve_transcript_path(
+                    session_id, broken, {"cwd": cwd}
+                )
+
+            self.assertEqual(resolved, actual.resolve())
+
+    def test_keeps_broken_path_when_multiple_candidates_are_ambiguous(self):
+        with tempfile.TemporaryDirectory() as home:
+            projects = Path(home) / ".claude" / "projects"
+            session_id = "session-123"
+            for directory in ("project-a", "project-b"):
+                candidate = projects / directory / f"{session_id}.jsonl"
+                candidate.parent.mkdir(parents=True, exist_ok=True)
+                candidate.touch()
+            broken = projects / "missing" / f"{session_id}.jsonl"
+
+            with patch.object(HOOK.Path, "home", return_value=Path(home)):
+                resolved = HOOK.resolve_transcript_path(session_id, broken, {})
+
+            self.assertEqual(resolved, broken)
+
+    def test_discovers_nested_desktop_workflow_agents(self):
+        with tempfile.TemporaryDirectory() as directory:
+            transcript = Path(directory) / "parent.jsonl"
+            transcript.touch()
+            root = Path(directory) / "parent" / "subagents"
+            direct = root / "agent-direct.jsonl"
+            nested = root / "workflows" / "wf-1" / "agent-nested.jsonl"
+            journal = root / "workflows" / "wf-1" / "journal.jsonl"
+            for path in (direct, nested, journal):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.touch()
+
+            discovered = HOOK.subagent_transcripts(transcript, "parent")
+
+            self.assertEqual(
+                discovered,
+                [
+                    ("parent:agent-direct", direct.resolve()),
+                    ("parent:agent-nested", nested.resolve()),
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Recover Claude Desktop transcript paths when the hook payload points to a non-existent home-scoped project directory.
- Prefer the candidate matching the payload `cwd`, fall back only when a single candidate exists, and fail open when resolution is ambiguous.
- Discover and incrementally upload Claude Desktop subagent and workflow transcripts nested below the parent session.
- Flush after each subagent transcript so large Desktop workflows do not overflow the bounded Langfuse SDK queue.
- Add regression tests for path recovery, ambiguity handling, and nested workflow-agent discovery.

## Root cause

Claude Desktop local-agent sessions can emit a hook payload such as:

```text
~/.claude/projects/-Users-user/<session-id>.jsonl
```

while the transcript is stored under the cwd-encoded project directory:

```text
~/.claude/projects/-Users-user-work-project/<session-id>.jsonl
```

The existing hook trusted the missing path and exited successfully, silently dropping the session. Desktop workflow agents are stored below `<parent-session>/subagents/**/agent-*.jsonl` and do not receive directly usable transcript paths, so their model usage was omitted as well.

## Impact

Claude Desktop main sessions and nested agents are collected without affecting terminal Claude Code behavior. Existing byte-offset state remains the deduplication boundary for every transcript.

## Validation

```text
uv run --with 'langfuse>=4.0,<5' --with socksio python -m unittest discover -s tests -v
python3 -m py_compile hooks/langfuse_hook.py
git diff --check
```

All three regression tests pass.
