### PR TITLE
feat(hook): opt-in deterministic trace IDs via CC_LANGFUSE_TRACE_SEED

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -56,6 +56,11 @@
       "title": "Capture skill instructions",
       "description": "Include the injected skill instruction text in the Skill tool span output",
       "default": false
+    },
+    "CC_LANGFUSE_TRACE_SEED": {
+      "type": "string",
+      "title": "Trace ID seed",
+      "description": "Optional. Derive deterministic trace ids as Langfuse.create_trace_id(seed=f\"{seed}:{turn_number}\") so external systems can precompute them. Use a unique seed per session (e.g. the --session-id UUID). Leave empty for auto-generated ids."
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The plugin requires or accepts:
 | `CC_LANGFUSE_MAX_CHARS` | Truncate captured inputs/outputs to this many characters (default 20000).                          |
 | `CC_LANGFUSE_SKILL_TAGS` | Tag traces with `skill:<name>` for every skill invoked in the turn (default true).                 |
 | `CC_LANGFUSE_CAPTURE_SKILL_CONTENT` | Include injected skill instruction text in the Skill tool span output (default false).  |
+| `CC_LANGFUSE_TRACE_SEED` | Optional. Opt-in seed for deterministic trace IDs — see [Deterministic trace IDs](#deterministic-trace-ids). |
 
 Get keys from your Langfuse project settings → API Keys.
 
@@ -70,6 +71,58 @@ Not captured:
 If you use the desktop app, switch to Code mode for hook-backed tracing. Regular Chat mode does not invoke Claude Code Stop or SessionEnd hooks and does not write the transcript file this plugin reads.
 
 State is kept in `~/.claude/state/langfuse_state.json` so re-runs only emit new turns.
+
+## Deterministic trace IDs
+
+By default, trace IDs are auto-generated, so external systems (CI harnesses, benchmark
+runners, dataset-experiment services) that run Claude Code headlessly have to poll the
+Langfuse API to discover the trace ID of a run. Setting `CC_LANGFUSE_TRACE_SEED` makes
+trace IDs predictable: any system that knows the seed can compute the trace ID of each
+turn **before** the trace exists.
+
+With the seed set, the trace ID for turn `N` (1-based, counted per session across hook
+runs) is derived as:
+
+```python
+from langfuse import Langfuse
+
+trace_id = Langfuse.create_trace_id(seed=f"{CC_LANGFUSE_TRACE_SEED}:{turn_number}")
+# equivalent to: hashlib.sha256(f"{seed}:{turn_number}".encode()).hexdigest()[:32]
+```
+
+Use a **unique seed per session** — otherwise two sessions collide on the same trace
+IDs. The recommended seed is the Claude session UUID you already pass via
+`claude -p --session-id`.
+
+Example: a harness runs a single-turn headless prompt and links the resulting trace to
+a Langfuse dataset run item without ever fetching the trace:
+
+```python
+import subprocess, uuid, os
+from langfuse import Langfuse
+
+langfuse = Langfuse()
+session_id = str(uuid.uuid4())
+
+# Precompute the trace ID for turn 1 — no polling needed.
+trace_id = Langfuse.create_trace_id(seed=f"{session_id}:1")
+
+# Link it to a dataset run item BEFORE the run.
+langfuse.api.dataset_run_items.create(
+    dataset_item_id=item.id,
+    run_name="claude-code-benchmark-v1",
+    trace_id=trace_id,
+)
+
+subprocess.run(
+    ["claude", "-p", "Refactor utils.py", "--session-id", session_id],
+    env={**os.environ, "CC_LANGFUSE_TRACE_SEED": session_id},
+)
+# When the hook uploads the turn, its trace appears in Langfuse under trace_id.
+```
+
+If derivation or wiring fails for any reason, the hook falls back to an auto-generated
+trace ID (fail-open, like the rest of the hook). Unset or empty seed = unchanged behavior.
 
 ## Privacy
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -13,6 +13,7 @@ Claude Code -> Langfuse hook
 import json
 import logging
 import os
+import random
 import sys
 import threading
 import time
@@ -61,12 +62,14 @@ class LangfuseConfig:
     secret_key: str
     host: str
     user_id: Optional[str]
+    trace_seed: Optional[str] = None
 
 def get_langfuse_config() -> Optional[LangfuseConfig]:
     public_key = _opt("LANGFUSE_PUBLIC_KEY") or _opt("CC_LANGFUSE_PUBLIC_KEY")
     secret_key = _opt("LANGFUSE_SECRET_KEY") or _opt("CC_LANGFUSE_SECRET_KEY")
     host = _opt("LANGFUSE_BASE_URL") or _opt("CC_LANGFUSE_BASE_URL") or "https://us.cloud.langfuse.com"
     user_id = _opt("LANGFUSE_USER_ID") or _opt("CC_LANGFUSE_USER_ID") or None
+    trace_seed = _opt("CC_LANGFUSE_TRACE_SEED") or None
 
     if not public_key or not secret_key:
         return None
@@ -76,6 +79,7 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
         secret_key=secret_key,
         host=host,
         user_id=user_id,
+        trace_seed=trace_seed,
     )
 
 def create_langfuse_client(config: LangfuseConfig) -> Optional[Langfuse]:
@@ -1030,9 +1034,79 @@ def _get_latest_timestamp(*timestamps: Optional[datetime]) -> Optional[datetime]
     present_timestamps = [timestamp for timestamp in timestamps if timestamp is not None]
     return max(present_timestamps) if present_timestamps else None
 
+# ---- Deterministic trace ids ----
+def _is_valid_trace_id_hex(trace_id: Any) -> bool:
+    if not isinstance(trace_id, str) or len(trace_id) != 32:
+        return False
+    try:
+        return int(trace_id, 16) != 0
+    except ValueError:
+        return False
+
+def derive_turn_trace_id(trace_seed: str, turn_number: int) -> Optional[str]:
+    """Derive the deterministic W3C trace id for a turn from CC_LANGFUSE_TRACE_SEED.
+
+    Formula: Langfuse.create_trace_id(seed=f"{trace_seed}:{turn_number}") — which
+    is sha256(seed_string).hexdigest()[:32]. The explicit sha256 fallback keeps
+    IDs identical to what external callers precompute with the SDK helper even
+    if the helper itself is unavailable.
+    """
+    seed_string = f"{trace_seed}:{turn_number}"
+    try:
+        create_trace_id = getattr(Langfuse, "create_trace_id", None)
+        if callable(create_trace_id):
+            trace_id = create_trace_id(seed=seed_string)
+            if _is_valid_trace_id_hex(trace_id):
+                return trace_id.lower()
+    except Exception as e:
+        debug(f"Langfuse.create_trace_id failed for {seed_string!r}: {e}")
+    try:
+        return hashlib.sha256(seed_string.encode("utf-8")).hexdigest()[:32]
+    except Exception:
+        return None
+
+def _build_forced_trace_context(trace_id_hex: str) -> Optional[Any]:
+    """Build an OTel context whose remote parent carries the forced trace id.
+
+    A root span started within this context adopts the trace id; its children
+    keep inheriting it as usual. Returns None (caller falls back to an
+    auto-generated id) when the context cannot be built.
+    """
+    try:
+        trace_id = int(trace_id_hex, 16)
+        if trace_id == 0:
+            return None
+        span_id = 0
+        while span_id == 0:
+            span_id = random.getrandbits(64)
+        parent_span_context = otel_trace_api.SpanContext(
+            trace_id=trace_id,
+            span_id=span_id,
+            is_remote=True,
+            trace_flags=otel_trace_api.TraceFlags(otel_trace_api.TraceFlags.SAMPLED),
+        )
+        return otel_trace_api.set_span_in_context(
+            otel_trace_api.NonRecordingSpan(parent_span_context)
+        )
+    except Exception as e:
+        debug(f"forced trace context for {trace_id_hex!r} failed: {e}")
+        return None
+
+def _start_root_otel_span(langfuse: Langfuse, name: str, start_ns: Optional[int],
+                          forced_trace_id: Optional[str]) -> Any:
+    if forced_trace_id:
+        context = _build_forced_trace_context(forced_trace_id)
+        if context is not None:
+            try:
+                return langfuse._otel_tracer.start_span(name=name, start_time=start_ns, context=context)
+            except Exception as e:
+                debug(f"start_span with forced trace id {forced_trace_id!r} failed: {e}")
+    return langfuse._otel_tracer.start_span(name=name, start_time=start_ns)
+
 def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
                      start_time: Optional[datetime],
                      parent_otel_span: Any = None,
+                     forced_trace_id: Optional[str] = None,
                      **obs_kwargs: Any) -> Any:
     """Create a Langfuse observation with an explicit OTel start_time.
 
@@ -1060,7 +1134,7 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
         with otel_trace_api.use_span(parent_otel_span, end_on_exit=False):
             otel_span = langfuse._otel_tracer.start_span(name=name, start_time=start_ns)
     else:
-        otel_span = langfuse._otel_tracer.start_span(name=name, start_time=start_ns)
+        otel_span = _start_root_otel_span(langfuse, name, start_ns, forced_trace_id)
     return langfuse._create_observation_from_otel_span(
         otel_span=otel_span,
         as_type=as_type,
@@ -1687,7 +1761,8 @@ def build_trace_metadata(
 
 def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, transcript_path: Path,
               user_id: Optional[str] = None,
-              subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
+              subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
+              trace_seed: Optional[str] = None) -> None:
     user_text_raw = extract_text_from_content(get_content_from_row(turn.user_msg))
     user_text, user_text_meta = truncate_text(user_text_raw)
 
@@ -1703,6 +1778,14 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
     trace_name = trace_display_name(session_id, turn_num)
     root_observation_name = "Conversational Turn"
 
+    # Opt-in deterministic trace ids: fail open to the auto-generated id.
+    forced_trace_id: Optional[str] = None
+    if trace_seed:
+        try:
+            forced_trace_id = derive_turn_trace_id(trace_seed, turn_num)
+        except Exception as e:
+            debug(f"trace id derivation failed for turn {turn_num}: {e}")
+
     with propagate_attributes(
         session_id=session_id,
         user_id=user_id,
@@ -1714,6 +1797,7 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
             name=root_observation_name,
             as_type="span",
             start_time=user_ts,
+            forced_trace_id=forced_trace_id,
             input={"role": "user", "content": user_text},
             metadata=trace_metadata,
         )
@@ -1738,6 +1822,7 @@ def emit_ready_turns(
     *,
     user_id: Optional[str],
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
+    trace_seed: Optional[str] = None,
 ) -> int:
     emitted = 0
     for turn in turns_to_emit:
@@ -1752,6 +1837,7 @@ def emit_ready_turns(
                 transcript_path,
                 user_id=user_id,
                 subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+                trace_seed=trace_seed,
             )
         except Exception as e:
             # Log at INFO so SDK incompatibilities (and other emit failures)
@@ -1799,6 +1885,7 @@ def emit_new_turns_from_transcript(
             session_state,
             user_id=config.user_id,
             subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+            trace_seed=config.trace_seed,
         )
 
         session_state.turn_count += emitted

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import importlib.util
 import json
 import sys
@@ -19,7 +20,12 @@ def _install_langfuse_stubs() -> None:
     langfuse_module = types.ModuleType("langfuse")
 
     class Langfuse:
-        pass
+        @staticmethod
+        def create_trace_id(*, seed: str | None = None) -> str:
+            # Mirrors langfuse v4: seeded trace ids are sha256(seed)[:32].
+            if seed:
+                return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:32]
+            return "f" * 32
 
     @contextlib.contextmanager
     def propagate_attributes(**_: Any) -> Iterator[None]:
@@ -36,7 +42,31 @@ def _install_langfuse_stubs() -> None:
     def use_span(*_: Any, **__: Any) -> Iterator[None]:
         yield
 
+    class TraceFlags(int):
+        SAMPLED = 0x01
+
+    class SpanContext:
+        def __init__(self, trace_id: int, span_id: int, is_remote: bool, trace_flags: Any = None) -> None:
+            self.trace_id = trace_id
+            self.span_id = span_id
+            self.is_remote = is_remote
+            self.trace_flags = trace_flags
+
+    class NonRecordingSpan:
+        def __init__(self, span_context: SpanContext) -> None:
+            self._span_context = span_context
+
+        def get_span_context(self) -> SpanContext:
+            return self._span_context
+
+    def set_span_in_context(span: Any, context: Any = None) -> dict[str, Any]:
+        return {"current_span": span}
+
     trace_module.use_span = use_span
+    trace_module.TraceFlags = TraceFlags
+    trace_module.SpanContext = SpanContext
+    trace_module.NonRecordingSpan = NonRecordingSpan
+    trace_module.set_span_in_context = set_span_in_context
     opentelemetry_module.trace = trace_module
     sys.modules["opentelemetry"] = opentelemetry_module
     sys.modules["opentelemetry.trace"] = trace_module
@@ -73,14 +103,15 @@ def read_fixture_jsonl() -> Any:
 
 
 class FakeOtelSpan:
-    def __init__(self, name: str, start_time: int | None) -> None:
+    def __init__(self, name: str, start_time: int | None, context: Any = None) -> None:
         self.name = name
         self.start_time = start_time
+        self.context = context
 
 
 class FakeTracer:
-    def start_span(self, *, name: str, start_time: int | None = None) -> FakeOtelSpan:
-        return FakeOtelSpan(name, start_time)
+    def start_span(self, *, name: str, start_time: int | None = None, context: Any = None) -> FakeOtelSpan:
+        return FakeOtelSpan(name, start_time, context)
 
 
 class FakeObservation:

--- a/tests/integration/test_deterministic_trace_ids.py
+++ b/tests/integration/test_deterministic_trace_ids.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def expected_trace_id(seed: str, turn_number: int) -> int:
+    """The formula external systems use: Langfuse.create_trace_id(seed=f"{seed}:{turn}")."""
+    return int(hashlib.sha256(f"{seed}:{turn_number}".encode("utf-8")).hexdigest()[:32], 16)
+
+
+def write_two_turn_transcript(tmp_path: Path) -> Path:
+    rows = [
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "sessionId": "session-seeded",
+            "uuid": "user-1",
+            "message": {"role": "user", "content": "First question."},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:01.000Z",
+            "sessionId": "session-seeded",
+            "uuid": "assistant-1",
+            "message": {
+                "id": "msg-1",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": [{"type": "text", "text": "First answer."}],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:02.000Z",
+            "sessionId": "session-seeded",
+            "uuid": "user-2",
+            "message": {"role": "user", "content": "Second question."},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:03.000Z",
+            "sessionId": "session-seeded",
+            "uuid": "assistant-2",
+            "message": {
+                "id": "msg-2",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": [{"type": "text", "text": "Second answer."}],
+            },
+        },
+    ]
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    return transcript
+
+
+def get_root_observations(fake_langfuse: Any) -> list[Any]:
+    return [o for o in fake_langfuse.observations if o.name == "Conversational Turn"]
+
+
+def get_forced_trace_id(observation: Any) -> int | None:
+    """Trace id forced onto a root span via its remote parent context, if any."""
+    context = observation._otel_span.context
+    if context is None:
+        return None
+    return context["current_span"].get_span_context().trace_id
+
+
+def test_seeded_turns_get_individually_predictable_trace_ids(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    seed = "5b6e9821-3f0a-4b8f-9d0e-000000000001"
+    config = hook_module.LangfuseConfig(
+        "public", "secret", "https://example.test", "user-1", trace_seed=seed
+    )
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-seeded", transcript
+    )
+
+    assert emitted == 2
+    roots = get_root_observations(fake_langfuse)
+    assert len(roots) == 2
+    first_id, second_id = (get_forced_trace_id(root) for root in roots)
+    assert first_id == expected_trace_id(seed, 1)
+    assert second_id == expected_trace_id(seed, 2)
+    assert first_id != second_id
+
+    # The remote parent context carries a sampled, remote span context so
+    # the SDK exports the span under the derived trace id.
+    parent_context = roots[0]._otel_span.context["current_span"].get_span_context()
+    assert parent_context.is_remote is True
+    assert parent_context.span_id != 0
+    assert int(parent_context.trace_flags) & 0x01
+
+    # Only the root span is started in the forced context; children inherit
+    # the trace via their parent span as before.
+    for observation in fake_langfuse.observations:
+        if observation.name != "Conversational Turn":
+            assert observation._otel_span.context is None
+
+
+def test_turn_numbers_continue_across_hook_runs(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    seed = "session-abc"
+    config = hook_module.LangfuseConfig(
+        "public", "secret", "https://example.test", "user-1", trace_seed=seed
+    )
+
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-seeded", transcript)
+
+    # Append a third turn and run the hook again: it must derive from the
+    # persisted turn_count, not restart at 1.
+    with transcript.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:04.000Z",
+            "sessionId": "session-seeded",
+            "uuid": "user-3",
+            "message": {"role": "user", "content": "Third question."},
+        }) + "\n")
+        f.write(json.dumps({
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:05.000Z",
+            "sessionId": "session-seeded",
+            "uuid": "assistant-3",
+            "message": {
+                "id": "msg-3",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": [{"type": "text", "text": "Third answer."}],
+            },
+        }) + "\n")
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-seeded", transcript
+    )
+
+    assert emitted == 1
+    assert get_forced_trace_id(get_root_observations(fake_langfuse)[-1]) == expected_trace_id(seed, 3)
+
+
+def test_without_seed_trace_ids_stay_auto_generated(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-seeded", transcript
+    )
+
+    assert emitted == 2
+    for root in get_root_observations(fake_langfuse):
+        assert root._otel_span.context is None
+
+
+def test_derivation_failure_falls_back_to_auto_generated_trace_id(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    config = hook_module.LangfuseConfig(
+        "public", "secret", "https://example.test", "user-1", trace_seed="session-abc"
+    )
+
+    def _boom(trace_seed: str, turn_number: int) -> str:
+        raise RuntimeError("derivation broke")
+
+    monkeypatch.setattr(hook_module, "derive_turn_trace_id", _boom)
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-seeded", transcript
+    )
+
+    assert emitted == 2
+    roots = get_root_observations(fake_langfuse)
+    assert len(roots) == 2
+    for root in roots:
+        assert root._otel_span.context is None
+
+
+def test_forced_context_failure_falls_back_to_auto_generated_trace_id(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    config = hook_module.LangfuseConfig(
+        "public", "secret", "https://example.test", "user-1", trace_seed="session-abc"
+    )
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("otel context broke")
+
+    monkeypatch.setattr(hook_module.otel_trace_api, "SpanContext", _boom)
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-seeded", transcript
+    )
+
+    assert emitted == 2
+    for root in get_root_observations(fake_langfuse):
+        assert root._otel_span.context is None

--- a/tests/unit/test_trace_id_derivation.py
+++ b/tests/unit/test_trace_id_derivation.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+
+def sha256_trace_id(seed_string: str) -> str:
+    return hashlib.sha256(seed_string.encode("utf-8")).hexdigest()[:32]
+
+
+def test_derive_turn_trace_id_matches_sdk_seed_formula(hook_module):
+    assert hook_module.derive_turn_trace_id("my-session", 1) == sha256_trace_id("my-session:1")
+    assert hook_module.derive_turn_trace_id("my-session", 12) == sha256_trace_id("my-session:12")
+
+
+def test_derive_turn_trace_id_differs_per_turn(hook_module):
+    first = hook_module.derive_turn_trace_id("my-session", 1)
+    second = hook_module.derive_turn_trace_id("my-session", 2)
+    assert first != second
+    assert len(first) == len(second) == 32
+    int(first, 16)
+    int(second, 16)
+
+
+def test_derive_turn_trace_id_falls_back_to_sha256_when_sdk_helper_raises(
+    hook_module, monkeypatch: pytest.MonkeyPatch
+):
+    def _boom(*, seed: str | None = None) -> str:
+        raise RuntimeError("helper unavailable")
+
+    monkeypatch.setattr(hook_module.Langfuse, "create_trace_id", staticmethod(_boom))
+    assert hook_module.derive_turn_trace_id("my-session", 1) == sha256_trace_id("my-session:1")
+
+
+def test_derive_turn_trace_id_ignores_invalid_sdk_helper_result(
+    hook_module, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        hook_module.Langfuse, "create_trace_id", staticmethod(lambda *, seed=None: "not-a-trace-id")
+    )
+    assert hook_module.derive_turn_trace_id("my-session", 1) == sha256_trace_id("my-session:1")


### PR DESCRIPTION
## What

Adds an opt-in `CC_LANGFUSE_TRACE_SEED` option that makes per-turn trace IDs externally predictable. When set, the trace ID for turn N is derived as:

```python
Langfuse.create_trace_id(seed=f"{CC_LANGFUSE_TRACE_SEED}:{turn_number}")
# == hashlib.sha256(f"{seed}:{turn_number}".encode()).hexdigest()[:32]
```

Unset/empty seed = current behavior, no change.

## Why

External systems (CI harnesses, benchmark runners, dataset-experiment services) that run Claude Code headlessly control the session ID (`claude -p --session-id`) but not the trace ID, so linking the resulting trace to a Langfuse dataset run item required polling the API after the fact. With a seed, a harness can precompute the trace ID and call `dataset_run_items.create` before/without ever fetching the trace.

## How

- **Config**: `CC_LANGFUSE_TRACE_SEED` is read via the existing `_opt()` helper in `get_langfuse_config()` (both the `CLAUDE_PLUGIN_OPTION_` userConfig prefix and the plain env var work) and carried on `LangfuseConfig.trace_seed`. Also added to `plugin.json` userConfig so `/plugin configure` shows it.
- **Derivation**: `derive_turn_trace_id()` uses the SDK v4 helper `Langfuse.create_trace_id(seed=...)`, with an explicit `sha256(seed_string)[:32]` fallback that produces the identical value if the helper is missing or returns something invalid. SDK pin stays `langfuse>=4.0,<5`.
- **Wiring**: `_start_backdated()` gained a `forced_trace_id` kwarg. The root turn span is started inside an OTel context whose remote parent `SpanContext` carries the derived trace ID (fresh random span ID, `is_remote=True`, sampled flags) — the same mechanism the SDK's own `trace_context` param uses. Child generation/tool/subagent spans are untouched and inherit through `parent_otel_span` as before.
- **Failure mode**: every layer fails open — derivation errors, context-construction errors, and `start_span(context=...)` errors all fall back to the auto-generated ID; the hook never crashes.

## Tests

57 passed (48 existing + 9 new):

- `tests/unit/test_trace_id_derivation.py`: formula equality with the SDK seed formula, per-turn uniqueness, sha256 fallback when the SDK helper raises or returns an invalid value.
- `tests/integration/test_deterministic_trace_ids.py`: full `emit_new_turns_from_transcript` path — seeded turns 1 and 2 get exactly the precomputed IDs; turn numbering continues from persisted `turn_count` across hook runs (turn 3 predictable); unseeded runs keep auto IDs and no forced context; both failure injections (derivation raises, `SpanContext` raises) still emit all turns with auto IDs.
- `tests/conftest.py` stubs extended with `SpanContext`/`TraceFlags`/`NonRecordingSpan`/`set_span_in_context` and an SDK-faithful `create_trace_id`.

## Verification against the real SDK

Beyond the stub-based suite, I ran a script against real `langfuse` 4.x + OpenTelemetry confirming the acceptance criterion end-to-end: `Langfuse.create_trace_id(seed=f"{seed}:{turn}")` equals the hook's derived ID, the real OTel root span adopts it, children inherit it and parent to the root span, and the Langfuse observation's `.trace_id` (what the API/UI shows) equals the precomputed ID.

## Reviewer notes

- Only the root span per turn is affected; the backdating approach (`_start_backdated` talking to `langfuse._otel_tracer` directly) is unchanged.
- The exported root span carries a `parentSpanId` pointing at the synthetic remote parent that never arrives — this is exactly what Langfuse's documented distributed-tracing / `trace_context` mechanism produces, and the backend treats such spans as trace roots.
- Callers must use a unique seed per session (README recommends the `--session-id` UUID); reusing a seed across sessions collides trace IDs.
- README gained a "Deterministic trace IDs" section with the exact formula and a precompute-and-link harness example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)