### PR TITLE
fix(hook): skip langfuse/otel import when a run has nothing to emit

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -9,6 +9,7 @@
 Claude Code -> Langfuse hook
 
 """
+from __future__ import annotations
 
 import json
 import logging
@@ -25,12 +26,29 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 
-# ----------------- Langfuse import (fail-open) -----------------
-try:
-    from langfuse import Langfuse, propagate_attributes
-    from opentelemetry import trace as otel_trace_api
-except Exception:
-    sys.exit(0)
+# ----------------- Langfuse import (fail-open, lazy) -----------------
+# Importing langfuse/opentelemetry pulls in a real dependency resolution +
+# module graph (measured ~2.4s with a warm uv cache). SessionEnd hooks are
+# killed by the CLI shutdown deadline before that finishes, and the common
+# SessionEnd run has nothing new to emit anyway (Stop already covered it).
+# So the import is deferred until main() has confirmed there is actual work.
+Langfuse = None
+propagate_attributes = None
+otel_trace_api = None
+
+def _ensure_langfuse_imported() -> bool:
+    global Langfuse, propagate_attributes, otel_trace_api
+    if Langfuse is not None:
+        return True
+    try:
+        from langfuse import Langfuse as _Langfuse, propagate_attributes as _propagate_attributes
+        from opentelemetry import trace as _otel_trace_api
+    except Exception:
+        return False
+    Langfuse = _Langfuse
+    propagate_attributes = _propagate_attributes
+    otel_trace_api = _otel_trace_api
+    return True
 
 
 # ----------------- Paths -----------------
@@ -83,6 +101,8 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
     )
 
 def create_langfuse_client(config: LangfuseConfig) -> Optional[Langfuse]:
+    if not _ensure_langfuse_imported():
+        return None
     try:
         return Langfuse(
             public_key=config.public_key,
@@ -1962,6 +1982,28 @@ def flush_and_shutdown_langfuse_client(langfuse: Optional[Langfuse]) -> None:
 
 
 # ----------------- Main -----------------
+def _has_pending_work(session_id: str, transcript_path: Path) -> bool:
+    """Cheap check (no langfuse import, no lock) for whether this run has anything to emit.
+
+    Covers the common SessionEnd case: Stop already uploaded everything, so the
+    transcript has no bytes past the saved offset and nothing is deferred.
+    """
+    try:
+        offset = 0
+        pending = True
+        state = load_hook_state()
+        key = get_session_state_key(session_id, str(transcript_path))
+        entry = state.get(key)
+        if isinstance(entry, dict):
+            offset = int(entry.get("offset", 0))
+            pending = bool(entry.get("pending_agent_turns")) or bool(entry.get("pending_task_notifications"))
+        file_size = transcript_path.stat().st_size if transcript_path.exists() else 0
+        return pending or file_size != offset
+    except Exception:
+        # Fail open: if the cheap check itself breaks, fall through to the real path.
+        return True
+
+
 def main() -> int:
     start = time.time()
     debug("Hook started")
@@ -1977,6 +2019,10 @@ def main() -> int:
 
     session_id, transcript_path = hook_context
     flush_deferred_agent_turns = is_session_end_hook_payload(payload)
+
+    if not _has_pending_work(session_id, transcript_path):
+        debug("Nothing new to emit, skipping langfuse import")
+        return 0
 
     langfuse = create_langfuse_client(config)
     if langfuse is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,10 @@ def hook_module() -> Any:
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
+    # Tests exercise langfuse/otel internals directly (module.Langfuse, etc.), so
+    # force the otherwise-lazy import now. Stubs are already in sys.modules above,
+    # so this is instant — it doesn't reintroduce the real import cost being fixed.
+    assert module._ensure_langfuse_imported()
     return module
 
 

--- a/tests/unit/test_lazy_import_skips_when_no_work.py
+++ b/tests/unit/test_lazy_import_skips_when_no_work.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_hook_module_without_forcing_import():
+    """Load a throwaway copy of the hook module, deliberately NOT calling
+    _ensure_langfuse_imported() the way the shared `hook_module` fixture does.
+
+    This lets us observe whether main() itself ever triggers the import, which
+    is the actual behavior being fixed - the shared fixture forces the import
+    upfront (so other tests can poke module.Langfuse directly), which would
+    mask a regression here.
+    """
+    module_path = REPO_ROOT / "hooks" / "langfuse_hook.py"
+    spec = importlib.util.spec_from_file_location("langfuse_hook_lazy_import_probe", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_unconfigured_plugin_never_imports_langfuse(monkeypatch):
+    # Before this fix, langfuse/opentelemetry were imported at module load
+    # time unconditionally - so even a plugin with no Langfuse keys set paid
+    # the import cost on every single hook invocation before bailing out.
+    module = _load_hook_module_without_forcing_import()
+    assert module.Langfuse is None
+
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{}"))
+
+    assert module.main() == 0
+    assert module.Langfuse is None
+
+
+def test_missing_transcript_never_imports_langfuse(monkeypatch, tmp_path):
+    module = _load_hook_module_without_forcing_import()
+    assert module.Langfuse is None
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+    missing_transcript = tmp_path / "missing.jsonl"
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"sessionId": "s1", "transcriptPath": str(missing_transcript)})),
+    )
+
+    assert module.main() == 0
+    assert module.Langfuse is None
+
+
+def test_caught_up_session_never_imports_langfuse(monkeypatch, tmp_path):
+    module = _load_hook_module_without_forcing_import()
+    assert module.Langfuse is None
+
+    state_dir = tmp_path / "claude-state"
+    monkeypatch.setattr(module, "STATE_DIR", state_dir)
+    monkeypatch.setattr(module, "STATE_FILE", state_dir / "langfuse_state.json")
+    monkeypatch.setattr(module, "LOCK_FILE", state_dir / "langfuse_state.lock")
+    monkeypatch.setattr(module, "LOG_FILE", state_dir / "langfuse_hook.log")
+
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+
+    state = module.load_hook_state()
+    key = module.get_session_state_key("s1", str(transcript.resolve()))
+    session_state = module.get_session_state(state, key)
+    session_state.offset = transcript.stat().st_size
+    module.save_session_state(state, key, session_state)
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {"sessionId": "s1", "transcriptPath": str(transcript), "hookEventName": "SessionEnd"}
+            )
+        ),
+    )
+
+    assert module.main() == 0
+    assert module.Langfuse is None

--- a/tests/unit/test_pending_work_check.py
+++ b/tests/unit/test_pending_work_check.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+
+def _write_state(hook_module, session_id, transcript_path, **entry_overrides):
+    state = hook_module.load_hook_state()
+    key = hook_module.get_session_state_key(session_id, str(transcript_path))
+    session_state = hook_module.get_session_state(state, key)
+    for field_name, value in entry_overrides.items():
+        setattr(session_state, field_name, value)
+    hook_module.save_session_state(state, key, session_state)
+
+
+def test_no_pending_work_when_offset_matches_file_size_and_nothing_deferred(
+    hook_module, isolated_hook_state, tmp_path
+):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+    _write_state(hook_module, "s1", transcript, offset=transcript.stat().st_size)
+
+    assert hook_module._has_pending_work("s1", transcript) is False
+
+
+def test_pending_work_when_transcript_has_unread_bytes(hook_module, isolated_hook_state, tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+    _write_state(hook_module, "s1", transcript, offset=0)
+
+    assert hook_module._has_pending_work("s1", transcript) is True
+
+
+def test_pending_work_when_agent_turns_are_deferred(hook_module, isolated_hook_state, tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+    _write_state(
+        hook_module,
+        "s1",
+        transcript,
+        offset=transcript.stat().st_size,
+        pending_agent_turns=[{"turn": 1}],
+    )
+
+    assert hook_module._has_pending_work("s1", transcript) is True
+
+
+def test_pending_work_when_task_notifications_are_unresolved(hook_module, isolated_hook_state, tmp_path):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+    _write_state(
+        hook_module,
+        "s1",
+        transcript,
+        offset=transcript.stat().st_size,
+        pending_task_notifications=[{"tool_use_id": "abc"}],
+    )
+
+    assert hook_module._has_pending_work("s1", transcript) is True
+
+
+def test_pending_work_defaults_true_for_unknown_session(hook_module, isolated_hook_state, tmp_path):
+    # No saved state for this session yet (e.g. state file wiped, or a hook race) -
+    # fail open and take the real path rather than risk silently dropping data.
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("", encoding="utf-8")
+
+    assert hook_module._has_pending_work("never-seen", transcript) is True
+
+
+def test_main_skips_langfuse_client_creation_when_nothing_pending(
+    hook_module, isolated_hook_state, tmp_path, monkeypatch
+):
+    import io
+    import json
+    import sys
+
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text('{"type": "user"}\n', encoding="utf-8")
+    _write_state(hook_module, "s1", transcript, offset=transcript.stat().st_size)
+
+    monkeypatch.setattr(
+        sys, "stdin", io.StringIO(json.dumps({"sessionId": "s1", "transcriptPath": str(transcript)}))
+    )
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+
+    called = False
+
+    def _boom(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("create_langfuse_client should not run when nothing is pending")
+
+    monkeypatch.setattr(hook_module, "create_langfuse_client", _boom)
+
+    assert hook_module.main() == 0
+    assert called is False


### PR DESCRIPTION
## Problem

Fixes #13.

Every Claude Code session exit prints:

```
SessionEnd hook [...] failed: Hook cancelled
```

**Root cause:** `hooks/langfuse_hook.py` imports `langfuse` and `opentelemetry`
unconditionally at module load — before it has even checked the stdin payload,
whether the plugin is configured, or whether the transcript has any unread
bytes. That import is not free — the issue measured ~2.4s with a *warm* uv
cache (uv resolve + Python startup + `langfuse`/`opentelemetry` imports); a
cold start is worse. Claude Code's CLI shutdown does not wait that long for
`SessionEnd`, so the hook gets cancelled on effectively every exit — and the
common case has nothing new to upload anyway, since `Stop` already covered
the last turn.

## Fix

This implements suggested fix #1 from the issue: do the cheap checks first,
only pay for the import when there's real work. The fix is not
SessionEnd-specific — it generalizes to *any* hook invocation (`Stop` or
`SessionEnd`) that turns out to have nothing to do, which turned out to be a
strictly larger class of bug than the issue named:

- `from __future__ import annotations` so the many `langfuse: Langfuse` /
  `-> Optional[Langfuse]` type hints throughout the file don't force the
  import to happen at class/def time.
- The `langfuse`/`opentelemetry` imports move into `_ensure_langfuse_imported()`,
  called lazily from `create_langfuse_client()` — same fail-open behavior as
  before (returns `None`/`False` on import failure, no `sys.exit`).
- A new `_has_pending_work(session_id, transcript_path)` runs first in
  `main()`: it reads the persisted state entry (offset, `pending_agent_turns`,
  `pending_task_notifications`) and `stat()`s the transcript file — no lock,
  no imports. If the transcript has no bytes past the saved offset and
  nothing is deferred, `main()` returns `0` immediately.
- Because `main()` already returned early for an unconfigured plugin
  (`config is None`) and an invalid/missing-transcript payload
  (`hook_context is None`) *before* my `_has_pending_work` check even runs,
  those two paths now also skip the import entirely — previously they paid
  the full import cost on every single hook firing too, configured or not.
- Fails open: any exception in the cheap check, or an unrecognized session,
  falls through to the real import + emit path rather than risking a
  dropped turn.

## Verification

- `uv run pytest -q` → **73 passed** (64 existing + 9 new):
  - `tests/unit/test_pending_work_check.py` — `_has_pending_work()` unit
    cases (unread bytes, deferred agent turns, deferred task notifications,
    unknown session) plus one `main()` integration test asserting
    `create_langfuse_client` is never called when nothing's pending.
  - `tests/unit/test_lazy_import_skips_when_no_work.py` — loads a fresh copy
    of the module *without* forcing the eager import (unlike the shared
    `hook_module` fixture, which forces it so other tests can poke
    `module.Langfuse` directly) and asserts `module.Langfuse` stays `None`
    after `main()` for: an unconfigured plugin, a missing transcript path,
    and a caught-up SessionEnd run.
  - `tests/conftest.py`'s `hook_module` fixture now calls
    `_ensure_langfuse_imported()` once after loading, so existing tests that
    reference `hook_module.Langfuse` / `otel_trace_api` directly keep
    working — the stubs it installs are already in `sys.modules`, so that
    forced import is effectively free and doesn't reintroduce the cost being
    fixed.
- Manually timed the no-op `SessionEnd` case (offset caught up, nothing
  deferred) against a synthetic session, using the repo's local venv to hold
  `uv`'s own resolve overhead constant on both sides:
  - Before: `Processed 0 turns in 0.04s` but **still imports langfuse/otel**
    (~0.25s wall time end-to-end).
  - After: `Nothing new to emit, skipping langfuse import`, **no import at
    all** (~0.08s wall time end-to-end).
  - Isolated import cost alone (`from langfuse import ...` +
    `from opentelemetry import trace`) on a warm local venv: ~0.3s — on top
    of `uv`'s own resolve/startup, which is where the issue's ~2.4s figure
    comes from.

## Notes

- `Stop` firing behavior for a turn with actual new content is unchanged —
  new transcript bytes still trigger the full import + emit path exactly as
  before. This only short-circuits runs that have nothing to do.
- Left the `SessionEnd` hook registration itself alone (didn't take the
  "drop the hook" alternative from the issue), since it's still the only
  thing that flushes `pending_agent_turns` deferred from async agents at
  session close.
- No CI workflow or CONTRIBUTING.md exists in this repo yet, so I matched
  the existing conventions I could observe directly: dataclass-based state,
  fail-open try/except throughout, and the `tests/unit/` +
  `hook_module`/`isolated_hook_state` fixture pattern already used by the
  rest of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)