### PR TITLE
fix(hook): eliminate silent failure modes and heal desktop GUI tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Get keys from your Langfuse project settings → API Keys.
 
 One of:
 
-- [uv](https://docs.astral.sh/uv/) (recommended) on `PATH`. The hook uses `uv run --script` and installs the Langfuse SDK from the script metadata automatically. In addition to your `PATH`, the hook also looks in the standard install locations `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`.
+- [uv](https://docs.astral.sh/uv/) (recommended) on `PATH`. The hook uses `uv run --script` and installs the Langfuse SDK from the script metadata automatically.
 - Python 3.10+ as `python3` with `langfuse>=4.0,<5` installed in that Python environment. This is only used as a fallback when `uv` is not on `PATH`.
 
 On the first hook run, uv downloads the Langfuse SDK from PyPI (declared in the script header) and caches it. Offline or proxied machines fail this download and retry on every turn until the cache is warm; you can pre-warm it from a networked terminal:
@@ -184,8 +184,8 @@ Nearly every failure explains itself in `~/.claude/state/langfuse_hook.log`. Sen
 
 | What the log shows | Meaning | What to do |
 | --- | --- | --- |
-| No new lines at all | The hook never launched. Either the plugin is disabled, no usable runtime was found (no `uv`, no suitable `python3`), or uv could not download the SDK (offline/proxy) | Run `claude plugin list` **from the directory you use in the app**, since enable/disable can be project-scoped. Install uv in a standard location. Pre-warm the SDK download (see Requirements) |
-| `langfuse import failed (…) python=… PATH=…` | The Python that ran the hook cannot import the SDK; the line names the interpreter, version, and PATH | Install uv in a standard location, or make sure `python3` is 3.10+ with `langfuse>=4.0,<5` installed |
+| No new lines at all | The hook never launched. Either the plugin is disabled, no usable runtime was found (no `uv`, no suitable `python3`), or uv could not download the SDK (offline/proxy) | Run `claude plugin list` **from the directory you use in the app**, since enable/disable can be project-scoped. Install uv and make sure it is on the PATH of the app that launches Claude Code. Pre-warm the SDK download (see Requirements) |
+| `langfuse import failed (…) python=… PATH=…` | The Python that ran the hook cannot import the SDK; the line names the interpreter, version, and PATH | Install uv and make sure it is on the PATH the hook inherits (the log line shows that PATH), or make sure `python3` is 3.10+ with `langfuse>=4.0,<5` installed |
 | `Langfuse config incomplete: missing …` | The named key(s) did not reach the hook. Either not configured yet, or configured but not delivered | Configure via `/plugin configure`. If the line also says `loaded under plugin identity '@inline'`, see the desktop section below |
 | `Hook started` plus a skip reason (e.g. `Transcript path does not exist`) | The hook ran and skipped intentionally; these often come from background/utility sessions | Usually harmless. File an issue with the log line if actual turns are missing |
 | `Processed N turns …` but nothing in Langfuse | Turns were handed to the SDK but delivery failed afterwards; export errors go to stderr, not this log | Check `LANGFUSE_BASE_URL` (EU `https://cloud.langfuse.com` vs US `https://us.cloud.langfuse.com`), key validity, and network/proxy reachability |

--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ The marketplace command registers the plugin marketplace and refreshes its local
 
 Restart Claude Code after install so the hook configuration is loaded.
 
-Then configure the plugin from within a Claude Code session. This is a Claude Code slash command, not a shell command:
+Then configure the plugin from within a Claude Code session. This is a Claude Code slash command, not a shell command. Run `claude` first, then type it at the session prompt:
 
 ```text
-/plugin configure langfuse-observability@langfuse-observability
+$ claude
+> /plugin configure langfuse-observability@langfuse-observability
 ```
 
 Alternatively, pass configuration values during install:
@@ -48,10 +49,16 @@ Get keys from your Langfuse project settings → API Keys.
 
 One of:
 
-- [uv](https://docs.astral.sh/uv/) (recommended) on `PATH`. The hook uses `uv run --script` and installs the Langfuse SDK from the script metadata automatically.
+- [uv](https://docs.astral.sh/uv/) (recommended) on `PATH`. The hook uses `uv run --script` and installs the Langfuse SDK from the script metadata automatically. In addition to your `PATH`, the hook also looks in the standard install locations `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin`.
 - Python 3.10+ as `python3` with `langfuse>=4.0,<5` installed in that Python environment. This is only used as a fallback when `uv` is not on `PATH`.
 
-If neither is set up, the hook exits silently — no impact on Claude Code.
+On the first hook run, uv downloads the Langfuse SDK from PyPI (declared in the script header) and caches it. Offline or proxied machines fail this download and retry on every turn until the cache is warm; you can pre-warm it from a networked terminal:
+
+```bash
+echo '{}' | uv run --quiet --script <plugin-root>/hooks/langfuse_hook.py
+```
+
+If no usable runtime is set up, the hook exits without tracing, and Claude Code is never blocked or slowed. Failure reasons are written to `~/.claude/state/langfuse_hook.log` (see Troubleshooting).
 
 ## How it works
 
@@ -173,10 +180,41 @@ claude plugin uninstall langfuse-observability
 
 ## Troubleshooting
 
-- Nothing in Langfuse: check `~/.claude/state/langfuse_hook.log` (enable `CC_LANGFUSE_DEBUG`).
-- Desktop chat has no traces: regular Claude Desktop Chat mode is not hook-backed. Use the `claude` CLI or Claude Code GUI Code mode.
-- Hook not firing: confirm with `claude plugin list` that langfuse-observability is enabled; restart Claude Code.
-- langfuse import errors (no uv): install uv, or ensure the `python3` on your PATH is Python 3.10+ and has `langfuse>=4.0,<5` installed.
+Nearly every failure explains itself in `~/.claude/state/langfuse_hook.log`. Send one message, then match the newest lines against this table:
+
+| What the log shows | Meaning | What to do |
+| --- | --- | --- |
+| No new lines at all | The hook never launched. Either the plugin is disabled, no usable runtime was found (no `uv`, no suitable `python3`), or uv could not download the SDK (offline/proxy) | Run `claude plugin list` **from the directory you use in the app**, since enable/disable can be project-scoped. Install uv in a standard location. Pre-warm the SDK download (see Requirements) |
+| `langfuse import failed (…) python=… PATH=…` | The Python that ran the hook cannot import the SDK; the line names the interpreter, version, and PATH | Install uv in a standard location, or make sure `python3` is 3.10+ with `langfuse>=4.0,<5` installed |
+| `Langfuse config incomplete: missing …` | The named key(s) did not reach the hook. Either not configured yet, or configured but not delivered | Configure via `/plugin configure`. If the line also says `loaded under plugin identity '@inline'`, see the desktop section below |
+| `Hook started` plus a skip reason (e.g. `Transcript path does not exist`) | The hook ran and skipped intentionally; these often come from background/utility sessions | Usually harmless. File an issue with the log line if actual turns are missing |
+| `Processed N turns …` but nothing in Langfuse | Turns were handed to the SDK but delivery failed afterwards; export errors go to stderr, not this log | Check `LANGFUSE_BASE_URL` (EU `https://cloud.langfuse.com` vs US `https://us.cloud.langfuse.com`), key validity, and network/proxy reachability |
+
+`Hook started` and other `[DEBUG]` lines require debug logging (`CC_LANGFUSE_DEBUG=true` via `/plugin configure`); the failure lines above are written at `[INFO]` and appear without it. Regular Claude Desktop **Chat** mode is not hook-backed. Tracing covers the `claude` CLI and desktop **Code** mode.
+
+### Desktop app (GUI) sessions
+
+GUI apps do not read your shell profile. `export`ed variables in `~/.zshrc` never reach GUI-spawned hooks, and the app resolves its `PATH` once at launch. After installing uv, fully quit and relaunch the desktop app. Keys must be configured via `/plugin configure` (or `--config` at install), not via shell exports.
+
+### Plugin options not delivered in GUI sessions
+
+Recent Claude Desktop builds load user-installed plugins under a different plugin identity (`langfuse-observability@inline`), so keys configured via `/plugin configure` are not delivered to the hook. Terminal sessions work, desktop sessions stay silent. When this happens, the log line contains `loaded under plugin identity '@inline'`.
+
+As a **temporary workaround** until the upstream Claude Code fix lands, duplicate your full options under the inline identity in `~/.claude/settings.json`:
+
+```json
+"pluginConfigs": {
+  "langfuse-observability@inline": {
+    "options": {
+      "LANGFUSE_PUBLIC_KEY": "pk-lf-...",
+      "LANGFUSE_SECRET_KEY": "sk-lf-...",
+      "LANGFUSE_BASE_URL": "https://cloud.langfuse.com"
+    }
+  }
+}
+```
+
+The entry must include `LANGFUSE_SECRET_KEY` because the OS-keychain secret only applies to the installed identity. This stores the secret in plaintext, so consider a dedicated API key pair for the workaround period and remove the entry once the upstream fix ships. No restart is needed; settings are picked up on the next message.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ GUI apps do not read your shell profile. `export`ed variables in `~/.zshrc` neve
 
 Recent Claude Desktop builds load user-installed plugins under a different plugin identity (`langfuse-observability@inline`), so keys configured via `/plugin configure` are not delivered to the hook. Terminal sessions work, desktop sessions stay silent. When this happens, the log line contains `loaded under plugin identity '@inline'`.
 
-As a **temporary workaround** until the upstream Claude Code fix lands, duplicate your full options under the inline identity in `~/.claude/settings.json`:
+As a **temporary workaround**, duplicate your full options under the inline identity in `~/.claude/settings.json`:
 
 ```json
 "pluginConfigs": {
@@ -214,7 +214,7 @@ As a **temporary workaround** until the upstream Claude Code fix lands, duplicat
 }
 ```
 
-The entry must include `LANGFUSE_SECRET_KEY` because the OS-keychain secret only applies to the installed identity. This stores the secret in plaintext, so consider a dedicated API key pair for the workaround period and remove the entry once the upstream fix ships. No restart is needed; settings are picked up on the next message.
+The entry must include `LANGFUSE_SECRET_KEY` because the OS-keychain secret only applies to the installed identity. This stores the secret in plaintext, so consider a dedicated API key pair for the workaround period and remove the entry once it is no longer needed. No restart is needed; settings are picked up on the next message.
 
 ## License
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
+            "command": "export PATH=\"$PATH:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin\"; if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
           }
         ]
       }
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
+            "command": "export PATH=\"$PATH:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin\"; if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$PATH:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin\"; if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
+            "command": "if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
           }
         ]
       }
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$PATH:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin\"; if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
+            "command": "if command -v uv >/dev/null 2>&1; then exec uv run --quiet --script \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; else exec python3 \"${CLAUDE_PLUGIN_ROOT}\"/hooks/langfuse_hook.py; fi"
           }
         ]
       }

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -156,7 +156,10 @@ except Exception as e:
     info(
         f"langfuse import failed ({type(e).__name__}: {e}); "
         f"python={sys.version.split()[0]} executable={sys.executable} "
-        f"PATH={os.environ.get('PATH', '')}"
+        f"PATH={os.environ.get('PATH', '')}. "
+        "Hint: uv was not found on this PATH. If uv is installed, check that its "
+        "location is on the PATH seen by the app that launches Claude Code; "
+        "GUI apps often use a minimal PATH."
     )
     sys.exit(0)
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -25,14 +25,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 
-# ----------------- Langfuse import (fail-open) -----------------
-try:
-    from langfuse import Langfuse, propagate_attributes
-    from opentelemetry import trace as otel_trace_api
-except Exception:
-    sys.exit(0)
-
-
 # ----------------- Paths -----------------
 STATE_DIR = Path.home() / ".claude" / "state"
 LOG_FILE = STATE_DIR / "langfuse_hook.log"
@@ -82,17 +74,6 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
         trace_seed=trace_seed,
     )
 
-def create_langfuse_client(config: LangfuseConfig) -> Optional[Langfuse]:
-    try:
-        return Langfuse(
-            public_key=config.public_key,
-            secret_key=config.secret_key,
-            host=config.host,
-        )
-    except Exception:
-        return None
-
-
 # ----------------- Logging -----------------
 _logger: Optional[logging.Logger] = None
 
@@ -133,6 +114,31 @@ def info(msg: str) -> None:
             lg.info(msg)
         except Exception:
             pass
+
+
+# ----------------- Langfuse import (fail-open) -----------------
+# Everything above this guard runs before the SDK import and must stay
+# stdlib-only and parseable on Python 3.9 so this failure path can log.
+try:
+    from langfuse import Langfuse, propagate_attributes
+    from opentelemetry import trace as otel_trace_api
+except Exception as e:
+    info(
+        f"langfuse import failed ({type(e).__name__}: {e}); "
+        f"python={sys.version.split()[0]} executable={sys.executable} "
+        f"PATH={os.environ.get('PATH', '')}"
+    )
+    sys.exit(0)
+
+def create_langfuse_client(config: LangfuseConfig) -> Optional[Langfuse]:
+    try:
+        return Langfuse(
+            public_key=config.public_key,
+            secret_key=config.secret_key,
+            host=config.host,
+        )
+    except Exception:
+        return None
 
 
 # ----------------- Hook payload -----------------

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -82,12 +82,26 @@ def _missing_langfuse_keys() -> List[str]:
         missing.append("LANGFUSE_SECRET_KEY")
     return missing
 
+def _plugin_load_identity() -> str:
+    # CLAUDE_PLUGIN_DATA ends in "<plugin-name>-<identity>", so the identity this
+    # hook was loaded under is directly observable; empty when undeterminable.
+    base = Path(os.environ.get("CLAUDE_PLUGIN_DATA", "")).name
+    prefix = "langfuse-observability-"
+    return base[len(prefix):] if base.startswith(prefix) else ""
+
 def log_missing_langfuse_config() -> None:
     missing = ", ".join(_missing_langfuse_keys()) or "unknown keys"
-    info(
+    msg = (
         f"Langfuse config incomplete: missing {missing} "
-        "(checked CLAUDE_PLUGIN_OPTION_* and plain env vars); tracing disabled for this turn. "
+        "(checked CLAUDE_PLUGIN_OPTION_* and plain env vars); tracing disabled for this turn."
     )
+    identity = _plugin_load_identity()
+    if identity and identity != "langfuse-observability":
+        msg += (
+            f" Note: this hook was loaded under plugin identity '@{identity}'; options configured "
+            "under '@langfuse-observability' are not delivered to it."
+        )
+    info(msg)
 
 
 # ----------------- Logging -----------------

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -74,6 +74,22 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
         trace_seed=trace_seed,
     )
 
+def _missing_langfuse_keys() -> List[str]:
+    missing = []
+    if not (_opt("LANGFUSE_PUBLIC_KEY") or _opt("CC_LANGFUSE_PUBLIC_KEY")):
+        missing.append("LANGFUSE_PUBLIC_KEY")
+    if not (_opt("LANGFUSE_SECRET_KEY") or _opt("CC_LANGFUSE_SECRET_KEY")):
+        missing.append("LANGFUSE_SECRET_KEY")
+    return missing
+
+def log_missing_langfuse_config() -> None:
+    missing = ", ".join(_missing_langfuse_keys()) or "unknown keys"
+    info(
+        f"Langfuse config incomplete: missing {missing} "
+        "(checked CLAUDE_PLUGIN_OPTION_* and plain env vars); tracing disabled for this turn. "
+    )
+
+
 # ----------------- Logging -----------------
 _logger: Optional[logging.Logger] = None
 
@@ -137,7 +153,8 @@ def create_langfuse_client(config: LangfuseConfig) -> Optional[Langfuse]:
             secret_key=config.secret_key,
             host=config.host,
         )
-    except Exception:
+    except Exception as e:
+        info(f"Langfuse client creation failed ({type(e).__name__}: {e}); tracing disabled for this turn")
         return None
 
 
@@ -1974,6 +1991,7 @@ def main() -> int:
 
     config = get_langfuse_config()
     if config is None:
+        log_missing_langfuse_config()
         return 0
 
     payload = read_hook_payload()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import importlib.util
 import json
+import logging
 import sys
 import types
 from pathlib import Path
@@ -154,11 +155,29 @@ def fake_langfuse() -> FakeLangfuse:
     return FakeLangfuse()
 
 
-@pytest.fixture
-def isolated_hook_state(tmp_path: Path, hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> Path:
+def _reset_hook_logger(hook_module: Any) -> None:
+    # The logger is cached twice (hook module global + Python's process-global
+    # registry), so a handler bound to a stale log path would survive across tests.
+    hook_module._logger = None
+    logger = logging.getLogger("langfuse_hook")
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        with contextlib.suppress(Exception):
+            handler.close()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hook_env(tmp_path: Path, hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     state_dir = tmp_path / "claude-state"
     monkeypatch.setattr(hook_module, "STATE_DIR", state_dir)
     monkeypatch.setattr(hook_module, "STATE_FILE", state_dir / "langfuse_state.json")
     monkeypatch.setattr(hook_module, "LOCK_FILE", state_dir / "langfuse_state.lock")
     monkeypatch.setattr(hook_module, "LOG_FILE", state_dir / "langfuse_hook.log")
-    return state_dir
+    _reset_hook_logger(hook_module)
+    yield state_dir
+    _reset_hook_logger(hook_module)
+
+
+@pytest.fixture
+def isolated_hook_state(_isolated_hook_env: Path) -> Path:
+    return _isolated_hook_env

--- a/tests/unit/test_config_visibility.py
+++ b/tests/unit/test_config_visibility.py
@@ -32,7 +32,6 @@ def test_missing_keys_are_logged_at_info(hook_module: Any, clean_key_env: None) 
     assert "Langfuse config incomplete" in log
     assert "LANGFUSE_PUBLIC_KEY" in log
     assert "LANGFUSE_SECRET_KEY" in log
-    assert "README troubleshooting" in log
 
 
 def test_partial_keys_name_only_the_missing_one(

--- a/tests/unit/test_config_visibility.py
+++ b/tests/unit/test_config_visibility.py
@@ -13,12 +13,15 @@ KEY_NAMES = [
     "CC_LANGFUSE_SECRET_KEY",
 ]
 
+IDENTITY_NOTE_MARKER = "loaded under plugin identity"
+
 
 @pytest.fixture
 def clean_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for name in KEY_NAMES:
         monkeypatch.delenv(name, raising=False)
         monkeypatch.delenv(f"CLAUDE_PLUGIN_OPTION_{name}", raising=False)
+    monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
 
 
 def _read_log(hook_module: Any) -> str:
@@ -29,6 +32,7 @@ def test_missing_keys_are_logged_at_info(hook_module: Any, clean_key_env: None) 
     hook_module.log_missing_langfuse_config()
 
     log = _read_log(hook_module)
+    assert "[INFO]" in log
     assert "Langfuse config incomplete" in log
     assert "LANGFUSE_PUBLIC_KEY" in log
     assert "LANGFUSE_SECRET_KEY" in log
@@ -43,6 +47,72 @@ def test_partial_keys_name_only_the_missing_one(
 
     log = _read_log(hook_module)
     assert "missing LANGFUSE_SECRET_KEY (" in log
+
+
+def test_inline_identity_gets_identity_note(
+    hook_module: Any, clean_key_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "CLAUDE_PLUGIN_DATA", "/home/user/.claude/plugins/data/langfuse-observability-inline"
+    )
+
+    hook_module.log_missing_langfuse_config()
+
+    log = _read_log(hook_module)
+    assert f"{IDENTITY_NOTE_MARKER} '@inline'" in log
+    assert "are not delivered to it" in log
+    assert "LANGFUSE_SECRET_KEY" in log
+
+
+def test_inline_identity_note_survives_trailing_slash(
+    hook_module: Any, clean_key_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "CLAUDE_PLUGIN_DATA", "/home/user/.claude/plugins/data/langfuse-observability-inline/"
+    )
+
+    hook_module.log_missing_langfuse_config()
+
+    log = _read_log(hook_module)
+    assert f"{IDENTITY_NOTE_MARKER} '@inline'" in log
+
+
+def test_installed_identity_gets_no_identity_note(
+    hook_module: Any, clean_key_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "CLAUDE_PLUGIN_DATA",
+        "/home/user/.claude/plugins/data/langfuse-observability-langfuse-observability",
+    )
+
+    hook_module.log_missing_langfuse_config()
+
+    log = _read_log(hook_module)
+    assert "Langfuse config incomplete" in log
+    assert IDENTITY_NOTE_MARKER not in log
+
+
+@pytest.mark.parametrize(
+    "data_value",
+    [
+        None,
+        "/home/user/.claude/plugins/data/langfuse-observability",
+        "/home/user/.claude/plugins/data/some-other-plugin-inline",
+    ],
+)
+def test_unknown_identity_source_gets_no_identity_note(
+    hook_module: Any, clean_key_env: None, monkeypatch: pytest.MonkeyPatch, data_value: str | None
+) -> None:
+    if data_value is None:
+        monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+    else:
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", data_value)
+
+    hook_module.log_missing_langfuse_config()
+
+    log = _read_log(hook_module)
+    assert "Langfuse config incomplete" in log
+    assert IDENTITY_NOTE_MARKER not in log
 
 
 def test_client_creation_failure_is_logged(hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_config_visibility.py
+++ b/tests/unit/test_config_visibility.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+KEY_NAMES = [
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "CC_LANGFUSE_PUBLIC_KEY",
+    "CC_LANGFUSE_SECRET_KEY",
+]
+
+
+@pytest.fixture
+def clean_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in KEY_NAMES:
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(f"CLAUDE_PLUGIN_OPTION_{name}", raising=False)
+
+
+def _read_log(hook_module: Any) -> str:
+    return Path(hook_module.LOG_FILE).read_text(encoding="utf-8")
+
+
+def test_missing_keys_are_logged_at_info(hook_module: Any, clean_key_env: None) -> None:
+    hook_module.log_missing_langfuse_config()
+
+    log = _read_log(hook_module)
+    assert "Langfuse config incomplete" in log
+    assert "LANGFUSE_PUBLIC_KEY" in log
+    assert "LANGFUSE_SECRET_KEY" in log
+    assert "README troubleshooting" in log
+
+
+def test_partial_keys_name_only_the_missing_one(
+    hook_module: Any, clean_key_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+
+    hook_module.log_missing_langfuse_config()
+
+    log = _read_log(hook_module)
+    assert "missing LANGFUSE_SECRET_KEY (" in log
+
+
+def test_client_creation_failure_is_logged(hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    class ExplodingLangfuse:
+        def __init__(self, **_: Any) -> None:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(hook_module, "Langfuse", ExplodingLangfuse)
+    config = hook_module.LangfuseConfig(public_key="pk", secret_key="sk", host="h", user_id=None)
+
+    assert hook_module.create_langfuse_client(config) is None
+
+    log = _read_log(hook_module)
+    assert "Langfuse client creation failed" in log
+    assert "RuntimeError" in log

--- a/tests/unit/test_import_failure.py
+++ b/tests/unit/test_import_failure.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_import_failure_logs_and_exits_cleanly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Exec the hook as a fresh module: the autouse isolation fixture patches the
+    # session module's constants, so home must be redirected for this re-import.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setitem(sys.modules, "langfuse", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "langfuse_hook_import_probe", REPO_ROOT / "hooks" / "langfuse_hook.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+
+    with pytest.raises(SystemExit) as excinfo:
+        spec.loader.exec_module(module)
+
+    assert excinfo.value.code == 0
+    log_text = (tmp_path / ".claude" / "state" / "langfuse_hook.log").read_text(encoding="utf-8")
+    assert "langfuse import failed" in log_text
+    assert sys.version.split()[0] in log_text
+    assert sys.executable in log_text
+    assert "PATH=" in log_text

--- a/tests/unit/test_import_failure.py
+++ b/tests/unit/test_import_failure.py
@@ -33,3 +33,4 @@ def test_import_failure_logs_and_exits_cleanly(tmp_path: Path, monkeypatch: pyte
     assert sys.version.split()[0] in log_text
     assert sys.executable in log_text
     assert "PATH=" in log_text
+    assert "Hint: uv was not found on this PATH" in log_text


### PR DESCRIPTION
## Summary

Investigation of #12 (plugin works in the `claude` CLI but stays silent in Claude Desktop Code mode for some users) surfaced a structural problem. Every failure path in the hook exited with code 0 and wrote nothing, so misconfiguration, runtime problems, and an upstream plugin-identity mismatch in recent desktop builds were all indistinguishable from "working fine". The debug flag could not help because it is itself a plugin option and is not delivered in the identity-mismatch case.

This PR makes every handled failure explain itself in `~/.claude/state/langfuse_hook.log` without debug enabled, and fixes the one failure class the plugin can heal outright.

## Changes

- **Test isolation** (`cfeeccc`). The pytest suite redirected nothing before. An autouse fixture now points STATE_DIR, state, lock, and log paths to `tmp_path` and resets the doubly cached logger, so tests no longer write into the real `~/.claude/state/langfuse_hook.log`.
- **Import failures log before exiting** (`036748e`). The fail-open import guard moved below the logging section. On failure it writes one INFO line with the exception, Python version, executable, and PATH. Everything above the guard stays stdlib-only and Python-3.9-parseable so this path can always log.
- **Missing config logs the facts** (`3813959`, `bc16b8b`). When keys are missing, the log names which ones and which sources were checked. `create_langfuse_client` failures are logged instead of silently swallowed.
- **Plugin load identity is named** (`848af61`). `CLAUDE_PLUGIN_DATA` ends in the identity the hook was loaded under. When keys are missing and that identity differs from the installed one (`@inline` in recent desktop builds), the line states it. Facts only, derived from the hook's own environment.
- **PATH hardening in hooks.json** (`c9da572`). GUI-spawned hooks inherit the app's raw PATH, which often misses the directories uv is installed in. The wrapper now appends `~/.local/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` before probing. Appending means an existing uv always wins. This heals the "uv installed but unfindable" class outright.
- **README** (`74c93c4`). Troubleshooting is rewritten around the actual log messages (pattern, cause, fix), plus a desktop section covering the GUI environment rules and the identity-mismatch workaround, including that the keychain secret only applies to the installed identity.

## Verification

- Full suite green (74 tests), and a suite run no longer appends a single line to the real user log.
- Each failure class was reproduced before the fix and re-run after it, in Docker (19-cell matrix across runtimes, PATH, config, and network states) and natively on macOS. The former silent cases now produce, for example:

```
[INFO] langfuse import failed (ModuleNotFoundError: No module named 'langfuse'); python=3.9.6 executable=/Library/Developer/CommandLineTools/usr/bin/python3 PATH=/usr/bin:/bin
[INFO] Langfuse config incomplete: missing LANGFUSE_SECRET_KEY (checked CLAUDE_PLUGIN_OPTION_* and plain env vars); tracing disabled for this turn. Note: this hook was loaded under plugin identity '@inline'; options configured under '@langfuse-observability' are not delivered to it.
```

- The bare-launchd-PATH scenario (the desktop GUI condition) was verified end to end. Before the PATH fix it died silently; with it, the hook processes turns and the trace arrives in a local Langfuse instance.

Refs #12 · LFE-10939