### PR TITLE
fix: capture named teammate (agent-team) subagents — meta.json without toolUseId was silently dropped

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -326,10 +326,6 @@ def save_hook_state(state: Dict[str, Any]) -> None:
     except Exception as e:
         debug(f"save_hook_state failed: {e}")
 
-def save_session_state(global_state: Dict[str, Any], key: str, session_state: SessionState) -> None:
-    update_session_state(global_state, key, session_state)
-    save_hook_state(global_state)
-
 
 # ----------------- Transcript row parsing -----------------
 def get_content_from_row(row: Dict[str, Any]) -> Any:
@@ -989,6 +985,10 @@ def get_subagent_transcripts_by_tool_use_id(transcript_path: Path) -> Dict[str, 
 
         tool_use_id = metadata.get("toolUseId")
         if not isinstance(tool_use_id, str) or not tool_use_id:
+            # Named-teammate metas (agent teams) carry no toolUseId and cannot be
+            # keyed here; they are discovered and emitted by
+            # discover_teammate_transcripts / emit_teammate_transcripts instead,
+            # so this skip drops nothing — it is not a silent data loss.
             continue
 
         jsonl_path = meta_path.with_name(meta_path.name[: -len(".meta.json")] + ".jsonl")
@@ -1019,6 +1019,122 @@ def get_task_id_to_tool_use_id(
         if isinstance(agent_id, str) and agent_id:
             task_id_to_tool_use_id[agent_id] = tool_use_id
     return task_id_to_tool_use_id
+
+
+# ----------------- Named teammate (agent-team) discovery -----------------
+# Claude Code's agent-teams feature spawns long-lived "teammate" subagents whose
+# meta.json carries taskKind "in_process_teammate" and a `name`, but NO toolUseId.
+# The classic toolUseId->transcript map therefore never sees them, and their
+# transcripts — which grow across many parent turns as SendMessage resumes them —
+# would be emitted nowhere. We discover them by name, link them back to their
+# launching Agent tool_use, and emit their turns as their own top-level traces.
+#
+# Note on deferral: we deliberately do NOT route teammate completion rows
+# (<teammate-message> / <agent-message>) through the async-launch deferral
+# machinery (is_task_notification_row / pending_agent_turns). Deferral exists to
+# hold a launching turn open until its single subagent result can be nested into
+# the launching tool span. Teammates are a parallel, long-lived conversation
+# captured directly from their own transcript here, so their launching turn emits
+# normally and their work is emitted as independent traces — there is no deferral
+# to resolve, and teammate messages need not be treated as task notifications.
+TEAMMATE_TASK_KIND = "in_process_teammate"
+
+
+def get_teammate_name_to_tool_use_id(transcript_path: Path) -> Tuple[Dict[str, str], set]:
+    """Map a teammate `name` to the Agent tool_use id that launched it.
+
+    Named teammates are spawned by an Agent tool_use whose input.name equals the
+    teammate meta's `name` (the tool result corroborates via toolUseResult.name /
+    an "agent_id: <name>@..." line). Scans the parent transcript in file order and
+    keeps the first launch per name; names launched more than once are returned as
+    ambiguous so the caller can flag the linkage deterministically.
+    """
+    name_to_tool_use_id: Dict[str, str] = {}
+    ambiguous_names: set = set()
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return name_to_tool_use_id, ambiguous_names
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(row, dict):
+            continue
+        for tool_use in get_tool_use_blocks(get_content_from_row(row)):
+            if tool_use.get("name") not in ("Agent", "Task"):
+                continue
+            tool_input = tool_use.get("input")
+            name = tool_input.get("name") if isinstance(tool_input, dict) else None
+            tool_use_id = tool_use.get("id")
+            if not isinstance(name, str) or not name:
+                continue
+            if not isinstance(tool_use_id, str) or not tool_use_id:
+                continue
+            if name in name_to_tool_use_id:
+                # Same name launched more than once: linkage is ambiguous. Keep
+                # the first (earliest) launch deterministically and flag it.
+                ambiguous_names.add(name)
+                continue
+            name_to_tool_use_id[name] = tool_use_id
+    return name_to_tool_use_id, ambiguous_names
+
+
+def discover_teammate_transcripts(transcript_path: Path) -> List[Dict[str, Any]]:
+    """Discover named-teammate subagent transcripts (metas without a toolUseId).
+
+    Mirrors get_subagent_transcripts_by_tool_use_id but for the teammate meta
+    shape: no toolUseId, taskKind == "in_process_teammate" (or at least a `name`).
+    Returns one entry per teammate with its transcript path and identifying
+    metadata, in a stable (filename-sorted) order.
+    """
+    subagent_dir = transcript_path.with_suffix("") / "subagents"
+    if not subagent_dir.is_dir():
+        return []
+
+    teammates: List[Dict[str, Any]] = []
+    for meta_path in sorted(subagent_dir.glob("*.meta.json")):
+        try:
+            metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(metadata, dict):
+            continue
+
+        # Classic subagents are keyed by toolUseId elsewhere; only metas WITHOUT
+        # one and shaped like a teammate are handled here.
+        tool_use_id = metadata.get("toolUseId")
+        if isinstance(tool_use_id, str) and tool_use_id:
+            continue
+        name = metadata.get("name")
+        is_teammate = metadata.get("taskKind") == TEAMMATE_TASK_KIND or (
+            isinstance(name, str) and name
+        )
+        if not is_teammate:
+            continue
+
+        jsonl_path = meta_path.with_name(meta_path.name[: -len(".meta.json")] + ".jsonl")
+        if not jsonl_path.exists():
+            continue
+
+        agent_id = meta_path.name[: -len(".meta.json")]
+        if agent_id.startswith("agent-"):
+            agent_id = agent_id[len("agent-"):]
+
+        teammates.append({
+            "path": jsonl_path,
+            "name": name if isinstance(name, str) and name else agent_id,
+            "agent_id": agent_id,
+            "agent_type": metadata.get("agentType"),
+            "description": metadata.get("description"),
+            "team_name": metadata.get("teamName"),
+        })
+    return teammates
 
 
 # ----------------- Langfuse emit -----------------
@@ -1860,6 +1976,195 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn, tr
         trace_span.end(end_time=to_otel_nanoseconds(_get_latest_timestamp(turn_end_ts, last_assistant_ts, obs_end_ts, user_ts)))
 
 
+# ---- Named teammate (agent-team) emission ----
+def teammate_trace_display_name(name: str, teammate_turn_num: int, session_id: str) -> str:
+    return f"Teammate {name} - Turn {teammate_turn_num} ({short_session_label(session_id)})"
+
+
+def derive_teammate_trace_id(trace_seed: str, name: str, teammate_turn_num: int) -> Optional[str]:
+    """Deterministic trace id for a teammate turn.
+
+    Namespaced by teammate name so a teammate turn never collides with a main
+    conversation turn that shares the same number.
+    """
+    return derive_turn_trace_id(f"{trace_seed}:teammate:{name}", teammate_turn_num)
+
+
+def emit_teammate_turn(
+    langfuse: Langfuse,
+    session_id: str,
+    teammate: Dict[str, Any],
+    teammate_turn_num: int,
+    turn: Turn,
+    transcript_path: Path,
+    *,
+    user_id: Optional[str] = None,
+    launching_tool_use_id: Optional[str] = None,
+    ambiguous_name: bool = False,
+    trace_seed: Optional[str] = None,
+) -> None:
+    """Emit one teammate turn as its own top-level trace.
+
+    A teammate is a parallel, long-lived conversation, so its turns become their
+    own traces (like main-conversation turns) rather than nesting under the
+    launching turn — the launch happened many parent turns earlier and its trace
+    is long closed. Linkage to the launching Agent tool_use is carried as trace
+    metadata/tags (launching_tool_use_id, teammate:<name>), which is the
+    filterable, cross-process-safe form of "linking".
+    """
+    name = teammate.get("name") or "teammate"
+    user_text_raw = extract_text_from_content(get_content_from_row(turn.user_msg))
+    user_text, user_text_meta = truncate_text(user_text_raw)
+
+    last_assistant = turn.assistant_msgs[-1]
+    final_assistant_text, _ = truncate_text(extract_text_from_content(get_content_from_row(last_assistant)))
+
+    user_ts = parse_timestamp(turn.user_msg)
+    last_assistant_ts = parse_timestamp(last_assistant)
+    turn_end_ts = get_turn_end_timestamp(turn)
+
+    trace_metadata = build_trace_metadata(session_id, teammate_turn_num, turn, transcript_path, user_text_meta)
+    trace_metadata.update({
+        "teammate_name": name,
+        "teammate_turn_number": teammate_turn_num,
+        "team_name": teammate.get("team_name"),
+        "agent_type": teammate.get("agent_type"),
+        "launching_tool_use_id": launching_tool_use_id,
+    })
+
+    tags = ["claude-code", f"teammate:{name}"]
+    if launching_tool_use_id is None:
+        tags.append("teammate-unattributed")
+    if ambiguous_name:
+        tags.append("teammate-ambiguous-name")
+    if SKILL_TAGS:
+        tags += collect_skill_tags(turn)
+
+    trace_name = teammate_trace_display_name(name, teammate_turn_num, session_id)
+
+    forced_trace_id: Optional[str] = None
+    if trace_seed:
+        try:
+            forced_trace_id = derive_teammate_trace_id(trace_seed, name, teammate_turn_num)
+        except Exception as e:
+            debug(f"teammate trace id derivation failed for {name} turn {teammate_turn_num}: {e}")
+
+    with propagate_attributes(
+        session_id=session_id,
+        user_id=user_id,
+        trace_name=trace_name,
+        tags=tags,
+    ):
+        trace_span = _start_backdated(
+            langfuse,
+            name="Teammate Turn",
+            as_type="span",
+            start_time=user_ts,
+            forced_trace_id=forced_trace_id,
+            input={"role": "user", "content": user_text},
+            metadata=trace_metadata,
+        )
+        obs_end_ts = emit_turn_observations(
+            langfuse,
+            trace_span._otel_span,
+            turn,
+            user_ts,
+            generation_prefix="Teammate LLM Call",
+            # Nested subagents launched by a teammate live under the teammate's
+            # own transcript stem, not the parent's; they are out of scope here.
+            subagent_transcripts_by_tool_use_id=None,
+        )
+        trace_span.update(output={"role": "assistant", "content": final_assistant_text})
+        trace_span.end(end_time=to_otel_nanoseconds(_get_latest_timestamp(turn_end_ts, last_assistant_ts, obs_end_ts, user_ts)))
+
+
+def emit_teammate_transcripts(
+    langfuse: Langfuse,
+    config: LangfuseConfig,
+    session_id: str,
+    transcript_path: Path,
+    state: Dict[str, Any],
+    *,
+    flush_deferred_agent_turns: bool = False,
+) -> int:
+    """Emit newly-closed turns for every named teammate under this session.
+
+    Runs on every hook firing (Stop and SessionEnd), independent of whether the
+    parent produced new turns. Growth and idempotency reuse the existing session
+    state: each teammate transcript gets its own state entry keyed by its path,
+    and turn_count records how many of its turns have already been emitted.
+
+    A teammate is almost always mid-turn when a parent Stop fires, so the still-
+    growing final turn is held back until a newer turn closes it (or SessionEnd
+    flushes). This keeps emission idempotent — turn_count only advances, and a
+    turn is never emitted until it can no longer grow — at the cost of the final
+    turn landing at SessionEnd.
+    """
+    teammates = discover_teammate_transcripts(transcript_path)
+    if not teammates:
+        return 0
+
+    name_to_tool_use_id, ambiguous_names = get_teammate_name_to_tool_use_id(transcript_path)
+
+    emitted_total = 0
+    for teammate in teammates:
+        path = teammate.get("path")
+        if not isinstance(path, Path):
+            continue
+        name = teammate.get("name")
+        launching_tool_use_id = (
+            name_to_tool_use_id.get(name) if isinstance(name, str) else None
+        )
+        ambiguous = isinstance(name, str) and name in ambiguous_names
+        if launching_tool_use_id is None:
+            info(
+                f"Teammate transcript without a matched launching Agent tool_use: "
+                f"{name} ({path.name}); emitting as unattributed"
+            )
+
+        key = get_session_state_key(session_id, str(path))
+        teammate_state = get_session_state(state, key)
+        already_emitted = teammate_state.turn_count
+
+        rows = read_subagent_jsonl(path)
+        if not rows:
+            continue
+        turns = build_turns(rows)
+
+        # Emit every turn that can no longer grow: all but the trailing turn on a
+        # normal firing, and the trailing turn too when flushing at session end.
+        closable = len(turns) if flush_deferred_agent_turns else max(len(turns) - 1, 0)
+        if already_emitted >= closable:
+            if already_emitted:
+                # Keep the entry's "updated" fresh so it is not pruned mid-session.
+                update_session_state(state, key, teammate_state)
+            continue
+
+        for index in range(already_emitted, closable):
+            teammate_turn_num = index + 1
+            try:
+                emit_teammate_turn(
+                    langfuse,
+                    session_id,
+                    teammate,
+                    teammate_turn_num,
+                    turns[index],
+                    transcript_path,
+                    user_id=config.user_id,
+                    launching_tool_use_id=launching_tool_use_id,
+                    ambiguous_name=ambiguous,
+                    trace_seed=config.trace_seed,
+                )
+                emitted_total += 1
+            except Exception as e:
+                info(f"emit_teammate_turn failed ({name} turn {teammate_turn_num}): {type(e).__name__}: {e}")
+
+        teammate_state.turn_count = closable
+        update_session_state(state, key, teammate_state)
+
+    return emitted_total
+
+
 # ---- New turn emission orchestration ----
 def emit_ready_turns(
     langfuse: Langfuse,
@@ -1916,28 +2221,44 @@ def emit_new_turns_from_transcript(
             subagent_transcripts_by_tool_use_id,
             flush_deferred_agent_turns=flush_deferred_agent_turns,
         )
-        if not turns:
-            save_session_state(state, key, session_state)
-            return 0
 
-        turns_to_emit = get_turns_to_emit(
-            turns,
-            session_state,
-            flush_deferred_agent_turns=flush_deferred_agent_turns,
-        )
-        emitted = emit_ready_turns(
+        emitted = 0
+        if turns:
+            turns_to_emit = get_turns_to_emit(
+                turns,
+                session_state,
+                flush_deferred_agent_turns=flush_deferred_agent_turns,
+            )
+            emitted = emit_ready_turns(
+                langfuse,
+                session_id,
+                transcript_path,
+                turns_to_emit,
+                session_state,
+                user_id=config.user_id,
+                subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
+                trace_seed=config.trace_seed,
+            )
+            session_state.turn_count += emitted
+
+        # Persist parent progress into the shared state dict before the teammate
+        # pass, which adds its own per-transcript entries to the same dict; a
+        # single save_hook_state below writes them all.
+        update_session_state(state, key, session_state)
+
+        # Named teammates (agent teams) grow their own transcripts independently
+        # of the parent, so capture them on every firing — even when the parent
+        # produced no new turns this run.
+        emitted += emit_teammate_transcripts(
             langfuse,
+            config,
             session_id,
             transcript_path,
-            turns_to_emit,
-            session_state,
-            user_id=config.user_id,
-            subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
-            trace_seed=config.trace_seed,
+            state,
+            flush_deferred_agent_turns=flush_deferred_agent_turns,
         )
 
-        session_state.turn_count += emitted
-        save_session_state(state, key, session_state)
+        save_hook_state(state)
         return emitted
 
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -302,6 +302,37 @@ def update_session_state(global_state: Dict[str, Any], key: str, session_state: 
         "updated": datetime.now(timezone.utc).isoformat(),
     }
 
+
+@dataclass
+class TeammateProgress:
+    """Per-teammate-transcript emission progress, stored in the same global state
+    dict as SessionState (a separate entry keyed by the teammate's transcript
+    path — same store, same lock, same 30-day pruning, not a parallel store)."""
+    emitted_turns: int = 0        # Teammate turns already emitted.
+    last_size: int = 0            # Transcript byte size seen at the previous firing.
+    last_emitted_rowcount: int = 0  # Row count of the most-recently emitted turn.
+    settled: bool = False         # Previous firing emitted every turn incl. the tail.
+
+def get_teammate_progress(global_state: Dict[str, Any], key: str) -> TeammateProgress:
+    s = global_state.get(key, {})
+    if not isinstance(s, dict):
+        s = {}
+    return TeammateProgress(
+        emitted_turns=int(s.get("emitted_turns", 0)),
+        last_size=int(s.get("last_size", 0)),
+        last_emitted_rowcount=int(s.get("last_emitted_rowcount", 0)),
+        settled=bool(s.get("settled", False)),
+    )
+
+def update_teammate_progress(global_state: Dict[str, Any], key: str, progress: TeammateProgress) -> None:
+    global_state[key] = {
+        "emitted_turns": progress.emitted_turns,
+        "last_size": progress.last_size,
+        "last_emitted_rowcount": progress.last_emitted_rowcount,
+        "settled": progress.settled,
+        "updated": datetime.now(timezone.utc).isoformat(),
+    }
+
 def save_hook_state(state: Dict[str, Any]) -> None:
     try:
         # Drop session entries older than 30 days to keep the file bounded.
@@ -1034,9 +1065,11 @@ def get_task_id_to_tool_use_id(
 # machinery (is_task_notification_row / pending_agent_turns). Deferral exists to
 # hold a launching turn open until its single subagent result can be nested into
 # the launching tool span. Teammates are a parallel, long-lived conversation
-# captured directly from their own transcript here, so their launching turn emits
-# normally and their work is emitted as independent traces — there is no deferral
-# to resolve, and teammate messages need not be treated as task notifications.
+# captured directly from their own transcript here, so whatever the parent's
+# launching turn does — emit immediately or defer to SessionEnd, depending on
+# whether its tool result matches is_async_agent_launch_result — is orthogonal:
+# the teammate's work is emitted as independent traces either way, and teammate
+# messages need not be treated as task notifications.
 TEAMMATE_TASK_KIND = "in_process_teammate"
 
 
@@ -1116,6 +1149,12 @@ def discover_teammate_transcripts(transcript_path: Path) -> List[Dict[str, Any]]
             isinstance(name, str) and name
         )
         if not is_teammate:
+            # A meta with no toolUseId and no teammate shape fits neither
+            # discovery path; surface it loudly rather than dropping it silently.
+            info(
+                f"Subagent meta with no toolUseId and no teammate shape "
+                f"(name/taskKind): {meta_path.name}; not emitted"
+            )
             continue
 
         jsonl_path = meta_path.with_name(meta_path.name[: -len(".meta.json")] + ".jsonl")
@@ -1981,13 +2020,39 @@ def teammate_trace_display_name(name: str, teammate_turn_num: int, session_id: s
     return f"Teammate {name} - Turn {teammate_turn_num} ({short_session_label(session_id)})"
 
 
-def derive_teammate_trace_id(trace_seed: str, name: str, teammate_turn_num: int) -> Optional[str]:
+def derive_teammate_trace_id(trace_seed: str, agent_id: str, teammate_turn_num: int) -> Optional[str]:
     """Deterministic trace id for a teammate turn.
 
-    Namespaced by teammate name so a teammate turn never collides with a main
-    conversation turn that shares the same number.
+    Namespaced by the per-meta agent_id (unique per teammate transcript, hash
+    included), NOT the display name: two teammates can share a name, and keying
+    on the name would derive identical ids so the second teammate's turns would
+    upsert over — silently clobber — the first's token stream. It is also
+    namespaced away from main-conversation turns that share a number.
     """
-    return derive_turn_trace_id(f"{trace_seed}:teammate:{name}", teammate_turn_num)
+    return derive_turn_trace_id(f"{trace_seed}:teammate:{agent_id}", teammate_turn_num)
+
+
+def is_teammate_turn_complete(turn: Turn) -> bool:
+    """Whether a teammate turn can no longer grow: its final assistant message
+    ended the turn rather than awaiting a tool result.
+
+    Used only together with a "transcript unchanged since the previous firing"
+    check, so a momentary lull mid-tool-loop never counts as complete.
+    """
+    if not turn.assistant_msgs:
+        return False
+    last = turn.assistant_msgs[-1]
+    message = last.get("message")
+    stop_reason = message.get("stop_reason") if isinstance(message, dict) else None
+    if stop_reason == "tool_use":
+        return False
+    # Even without a stop_reason, a tool_use whose result has not landed means
+    # the turn is still in flight.
+    for tool_use in get_tool_use_blocks(get_content_from_row(last)):
+        tool_use_id = str(tool_use.get("id") or "")
+        if tool_use_id and tool_use_id not in turn.tool_results_by_id:
+            return False
+    return True
 
 
 def emit_teammate_turn(
@@ -2013,6 +2078,7 @@ def emit_teammate_turn(
     filterable, cross-process-safe form of "linking".
     """
     name = teammate.get("name") or "teammate"
+    agent_id = teammate.get("agent_id") or name
     user_text_raw = extract_text_from_content(get_content_from_row(turn.user_msg))
     user_text, user_text_meta = truncate_text(user_text_raw)
 
@@ -2045,9 +2111,9 @@ def emit_teammate_turn(
     forced_trace_id: Optional[str] = None
     if trace_seed:
         try:
-            forced_trace_id = derive_teammate_trace_id(trace_seed, name, teammate_turn_num)
+            forced_trace_id = derive_teammate_trace_id(trace_seed, agent_id, teammate_turn_num)
         except Exception as e:
-            debug(f"teammate trace id derivation failed for {name} turn {teammate_turn_num}: {e}")
+            debug(f"teammate trace id derivation failed for {agent_id} turn {teammate_turn_num}: {e}")
 
     with propagate_attributes(
         session_id=session_id,
@@ -2090,15 +2156,9 @@ def emit_teammate_transcripts(
     """Emit newly-closed turns for every named teammate under this session.
 
     Runs on every hook firing (Stop and SessionEnd), independent of whether the
-    parent produced new turns. Growth and idempotency reuse the existing session
-    state: each teammate transcript gets its own state entry keyed by its path,
-    and turn_count records how many of its turns have already been emitted.
-
-    A teammate is almost always mid-turn when a parent Stop fires, so the still-
-    growing final turn is held back until a newer turn closes it (or SessionEnd
-    flushes). This keeps emission idempotent — turn_count only advances, and a
-    turn is never emitted until it can no longer grow — at the cost of the final
-    turn landing at SessionEnd.
+    parent produced new turns. Each teammate is processed in isolation so one
+    teammate's failure never aborts the others (and never propagates to the
+    classic path, whose progress is already persisted before this runs).
     """
     teammates = discover_teammate_transcripts(transcript_path)
     if not teammates:
@@ -2108,61 +2168,146 @@ def emit_teammate_transcripts(
 
     emitted_total = 0
     for teammate in teammates:
-        path = teammate.get("path")
-        if not isinstance(path, Path):
-            continue
-        name = teammate.get("name")
-        launching_tool_use_id = (
-            name_to_tool_use_id.get(name) if isinstance(name, str) else None
-        )
-        ambiguous = isinstance(name, str) and name in ambiguous_names
-        if launching_tool_use_id is None:
-            info(
-                f"Teammate transcript without a matched launching Agent tool_use: "
-                f"{name} ({path.name}); emitting as unattributed"
+        try:
+            emitted_total += _emit_one_teammate(
+                langfuse,
+                config,
+                session_id,
+                transcript_path,
+                state,
+                teammate,
+                name_to_tool_use_id,
+                ambiguous_names,
+                flush=flush_deferred_agent_turns,
             )
-
-        key = get_session_state_key(session_id, str(path))
-        teammate_state = get_session_state(state, key)
-        already_emitted = teammate_state.turn_count
-
-        rows = read_subagent_jsonl(path)
-        if not rows:
-            continue
-        turns = build_turns(rows)
-
-        # Emit every turn that can no longer grow: all but the trailing turn on a
-        # normal firing, and the trailing turn too when flushing at session end.
-        closable = len(turns) if flush_deferred_agent_turns else max(len(turns) - 1, 0)
-        if already_emitted >= closable:
-            if already_emitted:
-                # Keep the entry's "updated" fresh so it is not pruned mid-session.
-                update_session_state(state, key, teammate_state)
-            continue
-
-        for index in range(already_emitted, closable):
-            teammate_turn_num = index + 1
-            try:
-                emit_teammate_turn(
-                    langfuse,
-                    session_id,
-                    teammate,
-                    teammate_turn_num,
-                    turns[index],
-                    transcript_path,
-                    user_id=config.user_id,
-                    launching_tool_use_id=launching_tool_use_id,
-                    ambiguous_name=ambiguous,
-                    trace_seed=config.trace_seed,
-                )
-                emitted_total += 1
-            except Exception as e:
-                info(f"emit_teammate_turn failed ({name} turn {teammate_turn_num}): {type(e).__name__}: {e}")
-
-        teammate_state.turn_count = closable
-        update_session_state(state, key, teammate_state)
-
+        except Exception as e:
+            info(f"teammate capture failed ({teammate.get('name')}): {type(e).__name__}: {e}")
     return emitted_total
+
+
+def _emit_one_teammate(
+    langfuse: Langfuse,
+    config: LangfuseConfig,
+    session_id: str,
+    transcript_path: Path,
+    state: Dict[str, Any],
+    teammate: Dict[str, Any],
+    name_to_tool_use_id: Dict[str, str],
+    ambiguous_names: set,
+    *,
+    flush: bool,
+) -> int:
+    """Emit one teammate's newly-closed turns and persist its progress.
+
+    Growth and idempotency reuse the shared state store (a TeammateProgress entry
+    keyed by the teammate's transcript path): emitted_turns only ever advances.
+
+    A teammate is usually mid-turn when a parent Stop fires, so the still-growing
+    final turn is held back until (a) a newer turn closes it, (b) the transcript
+    is unchanged since the previous firing and the final turn has ended — a
+    one-shot background teammate that finished and is never resumed, which would
+    otherwise wait for SessionEnd — or (c) SessionEnd flushes. A turn is never
+    emitted while it can still grow, so nothing is ever double-counted.
+    """
+    path = teammate.get("path")
+    if not isinstance(path, Path):
+        return 0
+
+    name = teammate.get("name")
+    launching_tool_use_id = name_to_tool_use_id.get(name) if isinstance(name, str) else None
+    ambiguous = isinstance(name, str) and name in ambiguous_names
+    if launching_tool_use_id is None:
+        info(
+            f"Teammate transcript without a matched launching Agent tool_use: "
+            f"{name} ({path.name}); emitting as unattributed"
+        )
+
+    key = get_session_state_key(session_id, str(path))
+    progress = get_teammate_progress(state, key)
+
+    try:
+        current_size = path.stat().st_size
+    except Exception:
+        current_size = 0
+
+    # Perf guard: once we have caught up to the whole transcript (settled) and it
+    # has not changed since the previous firing, there is nothing to do — skip the
+    # whole-file reread so the global state lock is not held reparsing idle
+    # teammates on every Stop of a long session.
+    if not flush and progress.settled and current_size > 0 and current_size == progress.last_size:
+        update_teammate_progress(state, key, progress)  # keep "updated" fresh
+        return 0
+
+    rows = read_subagent_jsonl(path)
+    if not rows:
+        return 0
+    turns = build_turns(rows)
+
+    stable = current_size > 0 and current_size == progress.last_size
+    already = progress.emitted_turns
+
+    # In-place growth of the most-recently emitted turn. Transcripts are
+    # append-only, so only the last emitted turn can grow after emission (a resume
+    # starts a new turn). Re-emitting is a safe corrective upsert only under a
+    # trace seed (identical deterministic id); without one it would duplicate, so
+    # log the undercount loudly instead.
+    start = already
+    if 0 < already <= len(turns):
+        grown_rowcount = len(turns[already - 1].rows)
+        if grown_rowcount > progress.last_emitted_rowcount:
+            if config.trace_seed:
+                start = already - 1  # re-emit the grown turn as an upsert
+            else:
+                info(
+                    f"Teammate {name} turn {already} grew after emission "
+                    f"({progress.last_emitted_rowcount} -> {grown_rowcount} rows); "
+                    f"undercount — set CC_LANGFUSE_TRACE_SEED to enable corrective re-emit"
+                )
+                progress.last_emitted_rowcount = grown_rowcount
+
+    if flush:
+        closable = len(turns)
+    elif stable and turns and is_teammate_turn_complete(turns[-1]):
+        closable = len(turns)
+    else:
+        closable = max(len(turns) - 1, 0)
+
+    last_emitted_rowcount = progress.last_emitted_rowcount
+    emitted = 0
+    for index in range(start, closable):
+        teammate_turn_num = index + 1
+        try:
+            emit_teammate_turn(
+                langfuse,
+                session_id,
+                teammate,
+                teammate_turn_num,
+                turns[index],
+                transcript_path,
+                user_id=config.user_id,
+                launching_tool_use_id=launching_tool_use_id,
+                ambiguous_name=ambiguous,
+                trace_seed=config.trace_seed,
+            )
+            emitted += 1
+            last_emitted_rowcount = len(turns[index].rows)
+        except Exception as e:
+            info(f"emit_teammate_turn failed ({name} turn {teammate_turn_num}): {type(e).__name__}: {e}")
+
+    progress.emitted_turns = max(already, closable)
+    if emitted:
+        progress.last_emitted_rowcount = last_emitted_rowcount
+    progress.last_size = current_size
+    # "Settled" means the perf guard may skip the next reread. It requires every
+    # turn emitted AND no un-re-emitted in-place growth on the last emitted turn,
+    # so a pending corrective upsert is never skipped over.
+    tail_grew = (
+        0 < progress.emitted_turns <= len(turns)
+        and len(turns[progress.emitted_turns - 1].rows) > progress.last_emitted_rowcount
+    )
+    progress.settled = progress.emitted_turns >= len(turns) and not tail_grew
+    update_teammate_progress(state, key, progress)
+    return emitted
 
 
 # ---- New turn emission orchestration ----
@@ -2241,24 +2386,29 @@ def emit_new_turns_from_transcript(
             )
             session_state.turn_count += emitted
 
-        # Persist parent progress into the shared state dict before the teammate
-        # pass, which adds its own per-transcript entries to the same dict; a
-        # single save_hook_state below writes them all.
+        # Persist classic progress immediately: the teammate pass below shares the
+        # same state dict, and a failure there must never discard the classic
+        # offsets already emitted this run (which would re-emit classic turns).
         update_session_state(state, key, session_state)
+        save_hook_state(state)
 
         # Named teammates (agent teams) grow their own transcripts independently
         # of the parent, so capture them on every firing — even when the parent
-        # produced no new turns this run.
-        emitted += emit_teammate_transcripts(
-            langfuse,
-            config,
-            session_id,
-            transcript_path,
-            state,
-            flush_deferred_agent_turns=flush_deferred_agent_turns,
-        )
-
-        save_hook_state(state)
+        # produced no new turns this run. Guarded so teammate capture can never
+        # break classic capture; a second save persists teammate progress.
+        try:
+            emitted += emit_teammate_transcripts(
+                langfuse,
+                config,
+                session_id,
+                transcript_path,
+                state,
+                flush_deferred_agent_turns=flush_deferred_agent_turns,
+            )
+        except Exception as e:
+            info(f"teammate capture pass failed: {type(e).__name__}: {e}")
+        finally:
+            save_hook_state(state)
         return emitted
 
 

--- a/tests/unit/test_teammate_capture.py
+++ b/tests/unit/test_teammate_capture.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+
+# ----------------- Synthetic transcript builders -----------------
+# Modeled on the real named-teammate shapes (Agent tool_use with input.name,
+# meta.json with taskKind "in_process_teammate" and no toolUseId, teammate
+# transcripts that look like ordinary user/assistant transcripts). No real
+# transcript content is copied.
+
+def _write_jsonl(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _append_jsonl(path: Path, rows: List[Dict[str, Any]]) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def make_parent_transcript(
+    path: Path,
+    session_id: str,
+    launches: List[Tuple[str, str]],
+) -> None:
+    """A one-turn parent that launches `launches` = [(teammate_name, tool_use_id)]."""
+    rows: List[Dict[str, Any]] = [
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "sessionId": session_id,
+            "uuid": "parent-user-1",
+            "cwd": "/repo",
+            "gitBranch": "main",
+            "origin": {"kind": "human"},
+            "message": {"role": "user", "content": "Spawn the team."},
+        }
+    ]
+    tool_uses = [
+        {
+            "type": "tool_use",
+            "id": tool_use_id,
+            "name": "Agent",
+            "input": {
+                "name": name,
+                "subagent_type": "general-purpose",
+                "description": f"Build {name}",
+                "prompt": "go",
+            },
+        }
+        for name, tool_use_id in launches
+    ]
+    rows.append(
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:01.000Z",
+            "sessionId": session_id,
+            "uuid": "parent-assistant-1",
+            "requestId": "req-parent-1",
+            "message": {
+                "id": "msg-parent-1",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": tool_uses,
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        }
+    )
+    _write_jsonl(path, rows)
+
+
+def teammate_meta(agent_id: str, name: str, team_name: str = "session-test") -> Dict[str, Any]:
+    return {
+        "agentType": name,
+        "description": f"Build {name}",
+        "name": name,
+        "spawnDepth": 0,
+        "model": "sonnet",
+        "taskKind": "in_process_teammate",
+        "teamName": team_name,
+        "color": "blue",
+        "permissionMode": "bypassPermissions",
+    }
+
+
+def teammate_turn_rows(
+    session_id: str,
+    agent_id: str,
+    index: int,
+    minute: int,
+    *,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+) -> List[Dict[str, Any]]:
+    ts = f"2026-01-01T00:{minute:02d}:00.000Z"
+    ts2 = f"2026-01-01T00:{minute:02d}:02.000Z"
+    return [
+        {
+            "type": "user",
+            "timestamp": ts,
+            "sessionId": session_id,
+            "agentId": agent_id,
+            "uuid": f"{agent_id}-user-{index}",
+            "message": {"role": "user", "content": f"Instruction {index}"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": ts2,
+            "sessionId": session_id,
+            "agentId": agent_id,
+            "uuid": f"{agent_id}-assistant-{index}",
+            "requestId": f"req-{agent_id}-{index}",
+            "message": {
+                "id": f"msg-{agent_id}-{index}",
+                "role": "assistant",
+                "model": "claude-sonnet-5",
+                "content": [{"type": "text", "text": f"Did work {index}"}],
+                "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+            },
+        },
+    ]
+
+
+def write_teammate(
+    transcript_path: Path,
+    session_id: str,
+    file_stem: str,
+    name: str,
+    turn_count: int,
+) -> Path:
+    """Create a teammate meta + transcript with `turn_count` turns; returns the jsonl path."""
+    subagent_dir = transcript_path.with_suffix("") / "subagents"
+    subagent_dir.mkdir(parents=True, exist_ok=True)
+    agent_id = file_stem
+    (subagent_dir / f"agent-{file_stem}.meta.json").write_text(
+        json.dumps(teammate_meta(agent_id, name)), encoding="utf-8"
+    )
+    jsonl_path = subagent_dir / f"agent-{file_stem}.jsonl"
+    rows: List[Dict[str, Any]] = []
+    for index in range(1, turn_count + 1):
+        rows.extend(teammate_turn_rows(session_id, agent_id, index, minute=index))
+    _write_jsonl(jsonl_path, rows)
+    return jsonl_path
+
+
+def make_config(hook_module: Any, trace_seed: Optional[str] = None) -> Any:
+    return hook_module.LangfuseConfig(
+        "public", "secret", "https://example.test", "user-1", trace_seed
+    )
+
+
+def teammate_turn_observations(fake_langfuse: Any) -> List[Any]:
+    return [obs for obs in fake_langfuse.observations if obs.name == "Teammate Turn"]
+
+
+# ----------------- Discovery -----------------
+
+def test_discovers_teammate_transcript_without_tool_use_id(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+
+    # A named teammate: no toolUseId, taskKind in_process_teammate.
+    (subagent_dir / "agent-abuilder-issue-4-hash.meta.json").write_text(
+        json.dumps(teammate_meta("abuilder-issue-4-hash", "builder-issue-4")),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-abuilder-issue-4-hash.jsonl").write_text("", encoding="utf-8")
+
+    # A classic subagent: has toolUseId, must NOT be picked up as a teammate.
+    (subagent_dir / "agent-classic.meta.json").write_text(
+        json.dumps({"agentType": "general-purpose", "description": "d", "toolUseId": "toolu_classic", "spawnDepth": 1}),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-classic.jsonl").write_text("", encoding="utf-8")
+
+    teammates = hook_module.discover_teammate_transcripts(transcript)
+
+    assert [t["name"] for t in teammates] == ["builder-issue-4"]
+    teammate = teammates[0]
+    assert teammate["team_name"] == "session-test"
+    assert teammate["agent_type"] == "builder-issue-4"
+    assert teammate["path"].name == "agent-abuilder-issue-4-hash.jsonl"
+
+    # The classic subagent still resolves only via the toolUseId map, unchanged.
+    classic = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
+    assert set(classic) == {"toolu_classic"}
+
+
+# ----------------- name -> tool_use linkage -----------------
+
+def test_matches_two_teammate_names_to_their_launching_tool_uses(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    make_parent_transcript(
+        transcript,
+        "session-test",
+        [("builder-issue-4", "toolu_4"), ("builder-issue-5", "toolu_5")],
+    )
+
+    name_to_id, ambiguous = hook_module.get_teammate_name_to_tool_use_id(transcript)
+
+    assert name_to_id == {"builder-issue-4": "toolu_4", "builder-issue-5": "toolu_5"}
+    assert ambiguous == set()
+
+
+def test_same_name_teammates_link_to_first_launch_deterministically(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    # Two launches share a name; the earliest (file order) wins and the name is
+    # flagged ambiguous.
+    make_parent_transcript(
+        transcript,
+        "session-test",
+        [("dup", "toolu_first"), ("dup", "toolu_second")],
+    )
+
+    name_to_id, ambiguous = hook_module.get_teammate_name_to_tool_use_id(transcript)
+
+    assert name_to_id == {"dup": "toolu_first"}
+    assert ambiguous == {"dup"}
+
+
+# ----------------- End-to-end emission -----------------
+
+def test_emits_teammate_generations_with_token_usage_and_linkage(
+    hook_module, fake_langfuse, isolated_hook_state
+):
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
+    # Two turns so exactly one (the first) closes on a normal firing.
+    write_teammate(transcript, session_id, "abuilder-4", "builder-issue-4", turn_count=2)
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, make_config(hook_module), session_id, transcript
+    )
+
+    # One parent turn + one closed teammate turn.
+    assert emitted == 2
+    teammate_turns = teammate_turn_observations(fake_langfuse)
+    assert len(teammate_turns) == 1
+
+    # Linkage lives in trace metadata.
+    assert teammate_turns[0].kwargs["metadata"]["launching_tool_use_id"] == "toolu_4"
+    assert teammate_turns[0].kwargs["metadata"]["teammate_name"] == "builder-issue-4"
+
+    # Token usage reaches the teammate generation.
+    generations = [obs for obs in fake_langfuse.observations if obs.name == "Teammate LLM Call 1"]
+    assert generations, "expected a teammate generation"
+    assert generations[0].kwargs["usage_details"] == {"input": 100, "output": 50}
+
+
+def test_delta_emission_across_two_firings(hook_module, fake_langfuse, isolated_hook_state):
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
+    teammate_jsonl = write_teammate(transcript, session_id, "abuilder-4", "builder-issue-4", turn_count=2)
+    config = make_config(hook_module)
+
+    # Firing 1 (Stop): 2 turns present, the trailing one is held back.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
+
+    # The teammate grows: turn 2 is now closed by a new turn 3 (the new trailing).
+    _append_jsonl(teammate_jsonl, teammate_turn_rows(session_id, "abuilder-4", 3, minute=3))
+
+    # Firing 2 (Stop): only the newly-closed turn 2 is emitted (delta), not turn 1 again.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert len(teammate_turn_observations(fake_langfuse)) == 2
+
+    # Firing 3 (SessionEnd): flush emits the final held-back turn 3.
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, session_id, transcript, flush_deferred_agent_turns=True
+    )
+    assert len(teammate_turn_observations(fake_langfuse)) == 3
+
+    # Persisted per-teammate progress marker reflects all three emitted turns.
+    state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
+    key = hook_module.get_session_state_key(session_id, str(teammate_jsonl))
+    assert state[key]["turn_count"] == 3
+
+
+def test_idempotent_repeated_firings_emit_nothing_new(hook_module, fake_langfuse, isolated_hook_state):
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
+    write_teammate(transcript, session_id, "abuilder-4", "builder-issue-4", turn_count=2)
+    config = make_config(hook_module)
+
+    first = hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    count_after_first = len(teammate_turn_observations(fake_langfuse))
+    assert count_after_first == 1
+
+    # No transcript growth between firings: nothing new for parent or teammate.
+    second = hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert second == 0
+    assert len(teammate_turn_observations(fake_langfuse)) == count_after_first
+
+
+def test_unattributed_teammate_emitted_with_tag(
+    hook_module, fake_langfuse, isolated_hook_state, monkeypatch
+):
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    # Parent launches a DIFFERENT name, so the teammate cannot be linked.
+    make_parent_transcript(transcript, session_id, [("some-other-agent", "toolu_x")])
+    write_teammate(transcript, session_id, "aorphan", "orphan-teammate", turn_count=2)
+
+    captured_tags: List[List[str]] = []
+    original = hook_module.propagate_attributes
+
+    def _capturing(**kwargs: Any):
+        captured_tags.append(list(kwargs.get("tags") or []))
+        return original(**kwargs)
+
+    monkeypatch.setattr(hook_module, "propagate_attributes", _capturing)
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, make_config(hook_module), session_id, transcript
+    )
+
+    teammate_turns = teammate_turn_observations(fake_langfuse)
+    assert len(teammate_turns) == 1
+    # No linkage in metadata...
+    assert teammate_turns[0].kwargs["metadata"]["launching_tool_use_id"] is None
+    # ...and the trace is tagged unattributed.
+    teammate_tag_sets = [tags for tags in captured_tags if any(t.startswith("teammate:") for t in tags)]
+    assert teammate_tag_sets, "expected a teammate trace with tags"
+    assert "teammate-unattributed" in teammate_tag_sets[0]
+    assert "teammate:orphan-teammate" in teammate_tag_sets[0]

--- a/tests/unit/test_teammate_capture.py
+++ b/tests/unit/test_teammate_capture.py
@@ -152,6 +152,62 @@ def write_teammate(
     return jsonl_path
 
 
+def teammate_inprogress_tail_rows(session_id: str, agent_id: str, index: int, minute: int) -> List[Dict[str, Any]]:
+    """A turn whose final assistant message ends on a tool_use with no result yet
+    (stop_reason 'tool_use') — i.e. still in flight, must never be closed early."""
+    ts = f"2026-01-01T00:{minute:02d}:00.000Z"
+    ts2 = f"2026-01-01T00:{minute:02d}:02.000Z"
+    return [
+        {
+            "type": "user",
+            "timestamp": ts,
+            "sessionId": session_id,
+            "agentId": agent_id,
+            "uuid": f"{agent_id}-user-{index}",
+            "message": {"role": "user", "content": f"Instruction {index}"},
+        },
+        {
+            "type": "assistant",
+            "timestamp": ts2,
+            "sessionId": session_id,
+            "agentId": agent_id,
+            "uuid": f"{agent_id}-assistant-{index}",
+            "requestId": f"req-{agent_id}-{index}",
+            "message": {
+                "id": f"msg-{agent_id}-{index}",
+                "role": "assistant",
+                "model": "claude-sonnet-5",
+                "stop_reason": "tool_use",
+                "content": [
+                    {"type": "tool_use", "id": f"toolu-{agent_id}-{index}", "name": "Bash", "input": {"command": "ls"}}
+                ],
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        },
+    ]
+
+
+def teammate_extra_assistant_row(session_id: str, agent_id: str, index: int, minute: int) -> Dict[str, Any]:
+    """An additional assistant row appended to an existing turn (in-place growth,
+    no new user row)."""
+    return {
+        "type": "assistant",
+        "timestamp": f"2026-01-01T00:{minute:02d}:30.000Z",
+        "sessionId": session_id,
+        "agentId": agent_id,
+        "uuid": f"{agent_id}-assistant-{index}-more",
+        "requestId": f"req-{agent_id}-{index}-more",
+        "message": {
+            "id": f"msg-{agent_id}-{index}-more",
+            "role": "assistant",
+            "model": "claude-sonnet-5",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": f"More work {index}"}],
+            "usage": {"input_tokens": 30, "output_tokens": 20},
+        },
+    }
+
+
 def make_config(hook_module: Any, trace_seed: Optional[str] = None) -> Any:
     return hook_module.LangfuseConfig(
         "public", "secret", "https://example.test", "user-1", trace_seed
@@ -286,24 +342,142 @@ def test_delta_emission_across_two_firings(hook_module, fake_langfuse, isolated_
     # Persisted per-teammate progress marker reflects all three emitted turns.
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     key = hook_module.get_session_state_key(session_id, str(teammate_jsonl))
-    assert state[key]["turn_count"] == 3
+    assert state[key]["emitted_turns"] == 3
 
 
-def test_idempotent_repeated_firings_emit_nothing_new(hook_module, fake_langfuse, isolated_hook_state):
+def test_completion_heuristic_emits_stable_finished_tail_then_is_idempotent(
+    hook_module, fake_langfuse, isolated_hook_state
+):
+    # A one-shot background teammate: a single finished turn, never resumed.
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
+    write_teammate(transcript, session_id, "abuilder-4", "builder-issue-4", turn_count=1)
+    config = make_config(hook_module)
+
+    # Firing 1 (Stop): the trailing turn is held back — first sighting, not yet
+    # known stable.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert len(teammate_turn_observations(fake_langfuse)) == 0
+
+    # Firing 2 (Stop): transcript unchanged since firing 1 and the turn has ended,
+    # so the completion heuristic closes it now instead of waiting for SessionEnd.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
+
+    # Firing 3 (Stop): settled and unchanged — nothing new (idempotent).
+    third = hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
+    # Only the (unchanged) parent turn could be counted; the teammate adds nothing.
+    assert third == 0
+
+
+def test_inprogress_tail_not_emitted_prematurely(hook_module, fake_langfuse, isolated_hook_state):
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
+    # Turn 1 complete; turn 2's final assistant message ends on an unresolved
+    # tool_use, so it is genuinely still in flight.
+    subagent_dir = transcript.with_suffix("") / "subagents"
+    subagent_dir.mkdir(parents=True, exist_ok=True)
+    (subagent_dir / "agent-abuilder-4.meta.json").write_text(
+        json.dumps(teammate_meta("abuilder-4", "builder-issue-4")), encoding="utf-8"
+    )
+    jsonl = subagent_dir / "agent-abuilder-4.jsonl"
+    rows = teammate_turn_rows(session_id, "abuilder-4", 1, minute=1)
+    rows += teammate_inprogress_tail_rows(session_id, "abuilder-4", 2, minute=2)
+    _write_jsonl(jsonl, rows)
+    config = make_config(hook_module)
+
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
+
+    # Even though the transcript is now stable, the in-flight tail must NOT close.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
+
+
+def test_same_name_teammates_get_distinct_trace_ids_under_seed(hook_module):
+    # The collision fix: two teammates that share a display name but have distinct
+    # per-meta agent_ids must derive distinct deterministic trace ids, or the
+    # second would upsert over the first's token stream.
+    seed = "seed-abc"
+    id_a = hook_module.derive_teammate_trace_id(seed, "adup-hash-a", 1)
+    id_b = hook_module.derive_teammate_trace_id(seed, "adup-hash-b", 1)
+    assert id_a and id_b and id_a != id_b
+    # Stable across turns and namespaced away from main-conversation turn ids.
+    assert hook_module.derive_teammate_trace_id(seed, "adup-hash-a", 1) == id_a
+    assert hook_module.derive_turn_trace_id(seed, 1) != id_a
+
+
+def test_classic_state_persisted_when_teammate_pass_raises(
+    hook_module, fake_langfuse, isolated_hook_state, monkeypatch
+):
     session_id = "session-test"
     transcript = isolated_hook_state / "transcript.jsonl"
     make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
     write_teammate(transcript, session_id, "abuilder-4", "builder-issue-4", turn_count=2)
-    config = make_config(hook_module)
 
-    first = hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
-    count_after_first = len(teammate_turn_observations(fake_langfuse))
-    assert count_after_first == 1
+    def _boom(*_a, **_k):
+        raise RuntimeError("teammate pass exploded")
 
-    # No transcript growth between firings: nothing new for parent or teammate.
-    second = hook_module.emit_new_turns_from_transcript(fake_langfuse, config, session_id, transcript)
-    assert second == 0
-    assert len(teammate_turn_observations(fake_langfuse)) == count_after_first
+    monkeypatch.setattr(hook_module, "emit_teammate_transcripts", _boom)
+
+    # The classic turn is emitted and its progress must survive the teammate crash.
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, make_config(hook_module), session_id, transcript
+    )
+    assert emitted == 1  # the parent turn
+
+    state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
+    parent_key = hook_module.get_session_state_key(session_id, str(transcript))
+    assert state[parent_key]["turn_count"] == 1
+
+
+def test_seed_mode_corrective_reemit_on_inplace_growth(hook_module, fake_langfuse, isolated_hook_state):
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
+    jsonl = write_teammate(transcript, session_id, "abuilder-4", "builder-issue-4", turn_count=1)
+    config = make_config(hook_module, trace_seed="seed-xyz")
+
+    # Flush emits the single turn.
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, session_id, transcript, flush_deferred_agent_turns=True
+    )
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
+
+    # The already-emitted turn grows in place (extra assistant row, no new user row).
+    _append_jsonl(jsonl, [teammate_extra_assistant_row(session_id, "abuilder-4", 1, minute=1)])
+
+    # Under a trace seed, re-emitting is a safe upsert (identical id): the grown
+    # turn is emitted again to correct the token count.
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, session_id, transcript, flush_deferred_agent_turns=True
+    )
+    assert len(teammate_turn_observations(fake_langfuse)) == 2
+
+
+def test_no_seed_inplace_growth_does_not_duplicate(hook_module, fake_langfuse, isolated_hook_state):
+    session_id = "session-test"
+    transcript = isolated_hook_state / "transcript.jsonl"
+    make_parent_transcript(transcript, session_id, [("builder-issue-4", "toolu_4")])
+    jsonl = write_teammate(transcript, session_id, "abuilder-4", "builder-issue-4", turn_count=1)
+    config = make_config(hook_module)  # no trace seed
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, session_id, transcript, flush_deferred_agent_turns=True
+    )
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
+
+    _append_jsonl(jsonl, [teammate_extra_assistant_row(session_id, "abuilder-4", 1, minute=1)])
+
+    # Without a seed, re-emitting would duplicate; the undercount is logged and the
+    # turn is NOT re-emitted.
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, session_id, transcript, flush_deferred_agent_turns=True
+    )
+    assert len(teammate_turn_observations(fake_langfuse)) == 1
 
 
 def test_unattributed_teammate_emitted_with_tag(


### PR DESCRIPTION
Fixes #28.

## Problem

Named teammate agents (Claude Code's agent-teams feature: an `Agent` tool call with a `name:`) write `subagents/*.meta.json` **without** `toolUseId` (`taskKind: "in_process_teammate"`). `get_subagent_transcripts_by_tool_use_id` skips such metas with a silent `continue`, so none of a teammate's generations or token usage ever reaches Langfuse. On the machine where we found this, 261 teammate transcripts were invisible while 1,640 classic metas (which do carry `toolUseId`) were captured. In one heavy multi-agent session that was ~464k in+out tokens across 424 generations — all dropped.

## Design

- **Discovery**: `discover_teammate_transcripts()` alongside the classic map — picks metas without `toolUseId` that are teammate-shaped (`taskKind`/`name`). The classic path is untouched; truly unclassifiable metas are now logged loudly instead of silently skipped.
- **Linkage**: teammate `name` is matched against `Agent`/`Task` tool_use `input.name` in the parent transcript and carried as trace metadata (`launching_tool_use_id`, `teammate_name`, `team_name`) and tags (`teammate:<name>`). Span-level nesting is impossible for a long-lived teammate whose transcript grows across many hook firings, so linkage is metadata/tags; unmatched transcripts emit as `teammate-unattributed` traces.
- **Emission**: each teammate turn is its own top-level trace ("Teammate Turn" span, generations with full `usage_details` on the same basis as main-loop turns), reusing the existing `emit_turn_observations` machinery. Deterministic ids (when `CC_LANGFUSE_TRACE_SEED` is set) are namespaced by the unique per-meta agent id: `{seed}:teammate:{agent_id}:{turn}`.
- **Incremental & idempotent**: per-teammate progress (`emitted_turns`, `last_size`, `last_emitted_rowcount`, `settled`) lives in the existing persisted state store — same file, same lock, same pruning. The still-growing trailing turn is held back; a conservative completion heuristic (transcript byte-stable since the previous firing AND the tail ends in a completed assistant message, no dangling tool_use) closes finished one-shot teammates on the next `Stop` instead of waiting for `SessionEnd`, bounding loss if a session is killed. In-place growth of an already-emitted turn re-emits as a corrective upsert in seed mode and logs the undercount loudly otherwise. A stat-based guard skips re-reading unchanged transcripts to keep lock hold time bounded.
- **Durability**: classic state is persisted immediately after the classic emit; the teammate pass is isolated per-teammate and cannot discard classic progress on failure.

## Tests

76 passed (64 pre-existing unmodified + 12 new in `tests/unit/test_teammate_capture.py`): discovery without `toolUseId`, name→tool_use matching (incl. deterministic same-name handling), delta emission across firings, idempotent repeated firings, seed-mode distinct ids for same-named teammates, corrective upsert on in-place growth, no-duplicate in no-seed mode, completion-heuristic both directions, crash-durability of classic state, unattributed fallback.

Validated against real transcripts end-to-end: 10 teammates discovered and linked, 27 turns emitted exactly once across four firings (17 + 9 + 1 + 0), invariant `emitted == sum(build_turns)` holding exactly.

Happy to adjust to your conventions — and to discuss a follow-up for a related pre-existing property we noticed while testing (emit failures advance the processed counter on both classic and teammate paths, so a transient Langfuse outage drops that turn's tokens with only a log line; seed-mode idempotency would allow safe retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
