### PR TITLE
fix: plain env vars win over machine-wide plugin options (per-project routing)

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -42,8 +42,14 @@ LOCK_FILE = STATE_DIR / "langfuse_state.lock"
 
 # ----------------- Configuration -----------------
 def _opt(name: str) -> str:
-    """Read a plugin userConfig value (CLAUDE_PLUGIN_OPTION_<NAME>) with a fallback to a plain env var."""
-    return os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name}") or os.environ.get(name) or ""
+    """Read a config value: plain env var first, plugin userConfig (CLAUDE_PLUGIN_OPTION_<NAME>) as fallback.
+
+    Claude Code stores userConfig at user (machine) scope only, while an `env` block in a
+    project's .claude/settings.local.json is per-repo. The plain env var wins so that a
+    multi-project machine can route each repo to its own Langfuse project; the wizard's
+    machine-wide value applies exactly where no repo-level value is set.
+    """
+    return os.environ.get(name) or os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name}") or ""
 
 DEBUG = _opt("CC_LANGFUSE_DEBUG").lower() == "true"
 SKILL_TAGS = (_opt("CC_LANGFUSE_SKILL_TAGS") or "true").lower() == "true"

--- a/tests/unit/test_config_precedence.py
+++ b/tests/unit/test_config_precedence.py
@@ -1,0 +1,37 @@
+"""Pins _opt's config precedence: repo env var over machine-wide wizard value.
+
+Claude Code stores plugin userConfig at user (machine) scope only; a project's
+.claude/settings.local.json `env` block is the only per-repo channel. The plain
+env var must therefore win, or one machine-wide wizard value would silently
+reroute every project's traces to a single Langfuse project.
+"""
+
+from typing import Any
+
+
+def test_plain_env_var_wins_over_wizard_option(hook_module: Any, monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-repo")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == "pk-lf-repo"
+
+
+def test_wizard_option_is_the_fallback_when_no_env_var_is_set(hook_module: Any, monkeypatch):
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == "pk-lf-machine"
+
+
+def test_empty_env_var_falls_through_to_wizard_option(hook_module: Any, monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == "pk-lf-machine"
+
+
+def test_neither_set_yields_empty_string(hook_module: Any, monkeypatch):
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", raising=False)
+
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == ""


### PR DESCRIPTION
Fixes #30.

Claude Code stores plugin `userConfig` at user (machine) scope only ([plugins reference](https://code.claude.com/docs/en/plugins-reference.md); no per-project `pluginConfigs`, see anthropics/claude-code#39455), so the wizard's values are machine-global. With the current precedence (`CLAUDE_PLUGIN_OPTION_*` first) one saved wizard config silently reroutes every project on the machine to a single Langfuse project, overriding each repo's own `env` block in `.claude/settings.local.json` — silent cross-project trace leakage for anyone tracing different repos to different Langfuse projects.

This PR flips `_opt` to read the plain env var first and the plugin option as fallback:

- No repo-level env set (the common single-project case): identical behavior — the wizard value applies.
- Multi-project machines: each repo's env block takes effect in that repo; the wizard value covers the rest.
- Behavior changes only when both are set — the case where the old precedence picked the wrong one.

Four tests pin the precedence, including the empty-string edge (empty env var falls through to the wizard value). Full suite passes.

Independent of #29 (teammate capture) — different defect, no shared code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)