### PR TITLE
feat(hook): attach headless Claude Code runs to an existing parent trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The plugin requires or accepts:
 | `CC_LANGFUSE_SKILL_TAGS` | Tag traces with `skill:<name>` for every skill invoked in the turn (default true).                 |
 | `CC_LANGFUSE_CAPTURE_SKILL_CONTENT` | Include injected skill instruction text in the Skill tool span output (default false).  |
 | `CC_LANGFUSE_TRACE_SEED` | Optional. Opt-in seed for deterministic trace IDs — see [Deterministic trace IDs](#deterministic-trace-ids). |
+| `CC_LANGFUSE_TRACEPARENT` | Optional, per run (env var, not plugin config). W3C traceparent of an existing trace to attach to — see [Attach runs to an existing trace](#attach-runs-to-an-existing-trace). |
+| `CC_LANGFUSE_PARENT_TRACE_ID` / `CC_LANGFUSE_PARENT_SPAN_ID` | Optional, per run. Explicit alternative to `CC_LANGFUSE_TRACEPARENT` (32-hex trace id + 16-hex span id). |
 
 Get keys from your Langfuse project settings → API Keys.
 
@@ -130,6 +132,33 @@ subprocess.run(
 
 If derivation or wiring fails for any reason, the hook falls back to an auto-generated
 trace ID (fail-open, like the rest of the hook). Unset or empty seed = unchanged behavior.
+
+## Attach runs to an existing trace
+
+When your application launches Claude Code headlessly (`claude -p`) as one step of a
+larger, already-instrumented workflow, the agent run can join your application's
+existing Langfuse trace instead of creating separate root traces. Create a span for
+the agent run in your application (this becomes the run-level node), then pass its
+trace context as environment variables when launching Claude Code:
+
+```python
+from langfuse import get_client
+
+langfuse = get_client()
+
+with langfuse.start_as_current_span(name="Claude Code run") as run_span:
+    traceparent = f"00-{run_span.trace_id}-{run_span.id}-01"
+    subprocess.run(
+        ["claude", "-p", "Refactor utils.py"],
+        env={**os.environ, "CC_LANGFUSE_TRACEPARENT": traceparent},
+    )
+```
+
+Every conversational turn of the session (with its LLM calls, tool calls, and
+subagents) then appears as a child of your `Claude Code run` span, in your trace.
+Instead of `CC_LANGFUSE_TRACEPARENT` you can pass `CC_LANGFUSE_PARENT_TRACE_ID` and
+`CC_LANGFUSE_PARENT_SPAN_ID` explicitly.
+
 
 ## Privacy
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -10,6 +10,7 @@ Claude Code -> Langfuse hook
 
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -1343,18 +1344,22 @@ def derive_turn_trace_id(trace_seed: str, turn_number: int) -> Optional[str]:
     except Exception:
         return None
 
-def _build_forced_trace_context(trace_id_hex: str) -> Optional[Any]:
+def _build_forced_trace_context(trace_id_hex: str,
+                                parent_span_id_hex: Optional[str] = None) -> Optional[Any]:
     """Build an OTel context whose remote parent carries the forced trace id.
 
     A root span started within this context adopts the trace id; its children
-    keep inheriting it as usual. Returns None (caller falls back to an
-    auto-generated id) when the context cannot be built.
+    keep inheriting it as usual. Without parent_span_id_hex the parent gets a
+    phantom span id that never exports (the span becomes the trace's root);
+    with it (attached mode) the span nests under that externally exported
+    span. Returns None (caller falls back to an auto-generated id) when the
+    context cannot be built.
     """
     try:
         trace_id = int(trace_id_hex, 16)
         if trace_id == 0:
             return None
-        span_id = 0
+        span_id = int(parent_span_id_hex, 16) if parent_span_id_hex else 0
         while span_id == 0:
             span_id = random.getrandbits(64)
         parent_span_context = otel_trace_api.SpanContext(
@@ -1371,9 +1376,10 @@ def _build_forced_trace_context(trace_id_hex: str) -> Optional[Any]:
         return None
 
 def _start_root_otel_span(langfuse: Langfuse, name: str, start_ns: Optional[int],
-                          forced_trace_id: Optional[str]) -> Any:
+                          forced_trace_id: Optional[str],
+                          forced_parent_span_id: Optional[str] = None) -> Any:
     if forced_trace_id:
-        context = _build_forced_trace_context(forced_trace_id)
+        context = _build_forced_trace_context(forced_trace_id, forced_parent_span_id)
         if context is not None:
             try:
                 return langfuse._otel_tracer.start_span(name=name, start_time=start_ns, context=context)
@@ -1386,6 +1392,7 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
                      parent_otel_span: Any = None,
                      as_root: bool = False,
                      forced_trace_id: Optional[str] = None,
+                     forced_parent_span_id: Optional[str] = None,
                      **obs_kwargs: Any) -> Any:
     """Create a Langfuse observation with an explicit OTel start_time.
 
@@ -1413,7 +1420,7 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
         with otel_trace_api.use_span(parent_otel_span, end_on_exit=False):
             otel_span = langfuse._otel_tracer.start_span(name=name, start_time=start_ns)
     else:
-        otel_span = _start_root_otel_span(langfuse, name, start_ns, forced_trace_id)
+        otel_span = _start_root_otel_span(langfuse, name, start_ns, forced_trace_id, forced_parent_span_id)
     if as_root:
         # SDK/server contract: spans under a synthetic trace-id carrier have a
         # parentSpanId that never exports, so the server only treats them as
@@ -2250,20 +2257,40 @@ def remote_parent(langfuse: Langfuse, session_id: str, user_row_uuid: Any,
 
 
 def open_turn_root_span(langfuse: Langfuse, session_id: str, turn_num: int, turn: Turn,
-                        transcript_path: Path, trace_seed: Optional[str] = None) -> Any:
+                        transcript_path: Path, trace_seed: Optional[str] = None,
+                        parent_context: Optional[Tuple[str, str]] = None) -> Any:
     """Open the turn's root span, backdated to the user message.
 
     The root exports exactly once, at the first firing that is allowed to
     emit the turn (async activity resolved, or turn closed); later firings
     only attach children under it via the remote-parent carrier.
 
-    With trace_seed set (CC_LANGFUSE_TRACE_SEED) the root adopts the
-    externally precomputable trace id derived from seed and turn number;
-    otherwise the session:user-row-uuid carrier pins the trace id.
+    With parent_context set (attached mode: an externally provided
+    trace id + span id), the turn joins the launching application's trace
+    and nests under that span — the application owns the trace root, so no
+    as_root marker is set. Otherwise, with trace_seed set
+    (CC_LANGFUSE_TRACE_SEED) the root adopts the externally precomputable
+    trace id derived from seed and turn number; otherwise the
+    session:user-row-uuid carrier pins the trace id.
     """
     user_text_raw = extract_text_from_content(get_content_from_row(turn.user_msg))
     user_text, user_text_meta = truncate_text(user_text_raw)
     trace_metadata = build_trace_metadata(session_id, turn_num, turn, transcript_path, user_text_meta)
+    if parent_context is not None:
+        parent_trace_id, parent_span_id = parent_context
+        trace_metadata["parent_trace_id"] = parent_trace_id
+        trace_metadata["parent_span_id"] = parent_span_id
+        return _start_backdated(
+            langfuse,
+            name="Conversational Turn",
+            as_type="span",
+            start_time=parse_timestamp(turn.user_msg),
+            forced_trace_id=parent_trace_id,
+            forced_parent_span_id=parent_span_id,
+            as_root=False,
+            input={"role": "user", "content": user_text},
+            metadata=trace_metadata,
+        )
     # Opt-in deterministic trace ids: fail open to the carrier-derived id.
     forced_trace_id: Optional[str] = None
     if trace_seed:
@@ -2306,7 +2333,8 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
               subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
               progress: Optional[Dict[str, Any]] = None,
               close: bool = True,
-              trace_seed: Optional[str] = None) -> Dict[str, Any]:
+              trace_seed: Optional[str] = None,
+              parent_context: Optional[Tuple[str, str]] = None) -> Dict[str, Any]:
     """Emit a turn, resuming from prior firings' progress.
 
     With no progress and close=True this is the classic one-shot emission.
@@ -2324,17 +2352,25 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
         emitted=set(k for k in (progress.get("emitted_keys") or []) if isinstance(k, str)),
         completed_only=not close,
     )
-    with propagate_attributes(
-        session_id=session_id,
-        user_id=user_id,
-        trace_name=trace_display_name(session_id, turn_num),
-        tags=get_trace_tags(turn, subagent_transcripts_by_tool_use_id),
-    ):
+    if parent_context is None:
+        attribute_propagation = propagate_attributes(
+            session_id=session_id,
+            user_id=user_id,
+            trace_name=trace_display_name(session_id, turn_num),
+            tags=get_trace_tags(turn, subagent_transcripts_by_tool_use_id),
+        )
+    else:
+        # Attached mode: trace name, session, user and tags are trace-level
+        # fields owned by the launching application's trace — propagating
+        # them would overwrite the application's own values server-side.
+        attribute_propagation = contextlib.nullcontext()
+    with attribute_propagation:
         trace_span = None
         root_span_id = progress.get("root_span_id")
         if not is_valid_span_id_hex(root_span_id):
             trace_span = open_turn_root_span(
-                langfuse, session_id, turn_num, turn, transcript_path, trace_seed=trace_seed
+                langfuse, session_id, turn_num, turn, transcript_path,
+                trace_seed=trace_seed, parent_context=parent_context,
             )
             root_span_id = getattr(trace_span, "id", None)
             progress["root_span_id"] = root_span_id
@@ -2343,10 +2379,11 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
         else:
             # Root span exported by an earlier firing: attach children to it
             # via a carrier. The stored trace id wins over re-derivation so
-            # seeded turns resume into the same trace.
+            # seeded and attached turns resume into the same trace.
             parent_otel_span = remote_parent(
                 langfuse, session_id, turn.user_msg.get("uuid"),
-                root_span_id=root_span_id, trace_id=progress.get("trace_id"),
+                root_span_id=root_span_id,
+                trace_id=progress.get("trace_id") or (parent_context[0] if parent_context else None),
             )
         obs_end_ts = emit_turn_observations(
             langfuse,
@@ -2386,6 +2423,7 @@ def emit_and_close_ready_turns(
     user_id: Optional[str],
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
     trace_seed: Optional[str] = None,
+    parent_context: Optional[Tuple[str, str]] = None,
 ) -> int:
     emitted = 0
     # Turns without a user-row uuid bypass assign_turn_numbers; seed their
@@ -2415,6 +2453,7 @@ def emit_and_close_ready_turns(
                 progress=progress,
                 close=True,
                 trace_seed=trace_seed,
+                parent_context=parent_context,
             )
         except Exception as e:
             # Log at INFO so SDK incompatibilities (and other emit failures)
@@ -2433,6 +2472,7 @@ def emit_ready_observations_of_open_turn(
     user_id: Optional[str],
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
     trace_seed: Optional[str] = None,
+    parent_context: Optional[Tuple[str, str]] = None,
 ) -> None:
     """Emit the held open turn once its async activity is provably resolved.
 
@@ -2475,6 +2515,7 @@ def emit_ready_observations_of_open_turn(
             progress=progress if isinstance(progress, dict) else None,
             close=False,
             trace_seed=trace_seed,
+            parent_context=parent_context,
         )
         session_state.turn_progress[user_row_uuid] = progress
     except Exception as e:
@@ -2520,6 +2561,7 @@ def emit_new_turns_from_transcript(
                 user_id=config.user_id,
                 subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
                 trace_seed=config.trace_seed,
+                parent_context=config.parent_context,
             )
 
         session_state.turn_count += emitted
@@ -2536,6 +2578,7 @@ def emit_new_turns_from_transcript(
             user_id=config.user_id,
             subagent_transcripts_by_tool_use_id=subagent_transcripts_by_tool_use_id,
             trace_seed=config.trace_seed,
+            parent_context=config.parent_context,
         )
 
         # Known limitation (accepted, like the crash-between-emit-and-save

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -55,6 +55,64 @@ class LangfuseConfig:
     host: str
     user_id: Optional[str]
     trace_seed: Optional[str] = None
+    parent_trace_id: Optional[str] = None
+    parent_span_id: Optional[str] = None
+
+    @property
+    def parent_context(self) -> Optional[Tuple[str, str]]:
+        """(trace_id, span_id) of an externally provided parent, if any."""
+        if self.parent_trace_id and self.parent_span_id:
+            return (self.parent_trace_id, self.parent_span_id)
+        return None
+
+def parse_traceparent(value: str) -> Optional[Tuple[str, str]]:
+    """Parse a W3C traceparent string into (trace_id, span_id).
+
+    Accepts the version-00 format `00-<32 hex trace id>-<16 hex span id>-<flags>`
+    (https://www.w3.org/TR/trace-context/). All-zero ids are invalid per spec.
+    The flags field is ignored (tolerant reader): the hook only needs the ids.
+    """
+    parts = value.strip().lower().split("-")
+    if len(parts) != 4:
+        return None
+    version, trace_id, span_id, _flags = parts
+    if version != "00":
+        return None
+    if not _is_valid_trace_id_hex(trace_id):
+        return None
+    if not is_valid_span_id_hex(span_id) or int(span_id, 16) == 0:
+        return None
+    return trace_id, span_id
+
+def get_parent_trace_context_from_env() -> Tuple[Optional[str], Optional[str]]:
+    """Read the opt-in parent trace context ("attached mode") from the env.
+
+    CC_LANGFUSE_TRACEPARENT (W3C format) wins over the explicit id pair.
+    Deliberately namespaced — bare TRACEPARENT is NOT read, because Claude
+    Code's native OTel telemetry injects TRACEPARENT into subprocess
+    environments and would silently reparent every trace.
+    """
+    traceparent = _opt("CC_LANGFUSE_TRACEPARENT")
+    if traceparent:
+        parsed = parse_traceparent(traceparent)
+        if parsed is not None:
+            return parsed
+        info(f"Ignoring malformed CC_LANGFUSE_TRACEPARENT {traceparent!r}")
+    parent_trace_id = _opt("CC_LANGFUSE_PARENT_TRACE_ID").strip().lower() or None
+    parent_span_id = _opt("CC_LANGFUSE_PARENT_SPAN_ID").strip().lower() or None
+    if parent_trace_id is None and parent_span_id is None:
+        return None, None
+    if (
+        not _is_valid_trace_id_hex(parent_trace_id)
+        or not is_valid_span_id_hex(parent_span_id)
+        or int(parent_span_id, 16) == 0
+    ):
+        info(
+            "Ignoring parent trace context: CC_LANGFUSE_PARENT_TRACE_ID and "
+            "CC_LANGFUSE_PARENT_SPAN_ID must both be valid non-zero hex ids"
+        )
+        return None, None
+    return parent_trace_id, parent_span_id
 
 def get_langfuse_config() -> Optional[LangfuseConfig]:
     public_key = _opt("LANGFUSE_PUBLIC_KEY") or _opt("CC_LANGFUSE_PUBLIC_KEY")
@@ -62,6 +120,12 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
     host = _opt("LANGFUSE_BASE_URL") or _opt("CC_LANGFUSE_BASE_URL") or "https://us.cloud.langfuse.com"
     user_id = _opt("LANGFUSE_USER_ID") or _opt("CC_LANGFUSE_USER_ID") or None
     trace_seed = _opt("CC_LANGFUSE_TRACE_SEED") or None
+    parent_trace_id, parent_span_id = get_parent_trace_context_from_env()
+    if parent_trace_id is not None and trace_seed is not None:
+        # Both features pin the root's trace id; the externally provided
+        # parent wins because it also carries the nesting intent.
+        info("CC_LANGFUSE_TRACE_SEED ignored: parent trace context takes precedence")
+        trace_seed = None
 
     if not public_key or not secret_key:
         return None
@@ -72,6 +136,8 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
         host=host,
         user_id=user_id,
         trace_seed=trace_seed,
+        parent_trace_id=parent_trace_id,
+        parent_span_id=parent_span_id,
     )
 
 def _missing_langfuse_keys() -> List[str]:

--- a/tests/integration/test_parent_trace_attachment.py
+++ b/tests/integration/test_parent_trace_attachment.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+PARENT_TRACE_ID = "1234567890abcdef1234567890abcdef"
+PARENT_SPAN_ID = "fedcba0987654321"
+
+
+def attached_config(hook_module: Any, **overrides: Any) -> Any:
+    kwargs: dict[str, Any] = dict(
+        parent_trace_id=PARENT_TRACE_ID,
+        parent_span_id=PARENT_SPAN_ID,
+    )
+    kwargs.update(overrides)
+    return hook_module.LangfuseConfig(
+        "public", "secret", "https://example.test", "user-1", **kwargs
+    )
+
+
+def write_two_turn_transcript(tmp_path: Path) -> Path:
+    rows = [
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "sessionId": "session-attached",
+            "uuid": "user-1",
+            "message": {"role": "user", "content": "First question."},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:01.000Z",
+            "sessionId": "session-attached",
+            "uuid": "assistant-1",
+            "message": {
+                "id": "msg-1",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": [{"type": "text", "text": "First answer."}],
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": "2026-01-01T00:00:02.000Z",
+            "sessionId": "session-attached",
+            "uuid": "user-2",
+            "message": {"role": "user", "content": "Second question."},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:03.000Z",
+            "sessionId": "session-attached",
+            "uuid": "assistant-2",
+            "message": {
+                "id": "msg-2",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": [{"type": "text", "text": "Second answer."}],
+            },
+        },
+    ]
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    return transcript
+
+
+def get_root_observations(fake_langfuse: Any) -> list[Any]:
+    return [o for o in fake_langfuse.observations if o.name == "Conversational Turn"]
+
+
+def get_remote_parent_span_context(observation: Any) -> Any | None:
+    context = observation._otel_span.context
+    if context is None:
+        return None
+    return context["current_span"].get_span_context()
+
+
+def test_attached_turns_nest_under_the_external_parent_span(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    config = attached_config(hook_module)
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-attached", transcript
+    )
+
+    # The trailing turn stays open but its root is already opened (async
+    # activity resolved), so both roots exist.
+    assert emitted == 1
+    roots = get_root_observations(fake_langfuse)
+    assert len(roots) == 2
+    for root in roots:
+        parent = get_remote_parent_span_context(root)
+        assert parent is not None
+        assert parent.trace_id == int(PARENT_TRACE_ID, 16)
+        assert parent.span_id == int(PARENT_SPAN_ID, 16)
+        assert parent.is_remote is True
+        assert int(parent.trace_flags) & 0x01
+
+
+def test_attached_roots_do_not_claim_the_trace_root(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = write_two_turn_transcript(tmp_path)
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, attached_config(hook_module), "session-attached", transcript
+    )
+
+    for root in get_root_observations(fake_langfuse):
+        attributes = root._otel_span.attributes
+        # The launching application owns the trace root.
+        assert "langfuse.internal.as_root" not in attributes
+        assert attributes.get("langfuse.internal.is_app_root") is False
+
+
+def test_attached_mode_does_not_propagate_trace_level_attributes(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    calls: list[dict[str, Any]] = []
+
+    @contextlib.contextmanager
+    def recording_propagate(**kwargs: Any):
+        calls.append(kwargs)
+        yield
+
+    monkeypatch.setattr(hook_module, "propagate_attributes", recording_propagate)
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, attached_config(hook_module), "session-attached", transcript
+    )
+    assert calls == []
+
+    # Standalone mode keeps propagating trace name, session, user and tags.
+    standalone_dir = tmp_path / "standalone"
+    standalone_dir.mkdir()
+    standalone = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, standalone, "session-standalone", write_two_turn_transcript(standalone_dir)
+    )
+    assert calls
+    assert all("trace_name" in call for call in calls)
+
+
+def test_attached_open_turn_resumes_without_reopening_its_root(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    config = attached_config(hook_module)
+
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-attached", transcript)
+    roots_after_first_firing = len(get_root_observations(fake_langfuse))
+
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-attached", transcript)
+
+    assert len(get_root_observations(fake_langfuse)) == roots_after_first_firing
+
+
+def test_carrier_failure_falls_back_to_standalone_emission(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    transcript = write_two_turn_transcript(tmp_path)
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("otel context broke")
+
+    monkeypatch.setattr(hook_module.otel_trace_api, "SpanContext", _boom)
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, attached_config(hook_module), "session-attached", transcript
+    )
+
+    # Turns still ship; they just cannot join the external trace.
+    assert emitted == 1
+    roots = get_root_observations(fake_langfuse)
+    assert len(roots) == 2
+    for root in roots:
+        assert root._otel_span.context is None
+
+
+def test_without_parent_context_behavior_is_unchanged(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = write_two_turn_transcript(tmp_path)
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-attached", transcript
+    )
+
+    assert emitted == 1
+    for root in get_root_observations(fake_langfuse):
+        assert root._otel_span.context is None
+        assert root._otel_span.attributes.get("langfuse.internal.as_root") is True

--- a/tests/unit/test_parent_trace_context.py
+++ b/tests/unit/test_parent_trace_context.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+
+VALID_TRACE_ID = "a" * 31 + "b"
+VALID_SPAN_ID = "c" * 15 + "d"
+VALID_TRACEPARENT = f"00-{VALID_TRACE_ID}-{VALID_SPAN_ID}-01"
+
+
+class TestParseTraceparent:
+    def test_valid_traceparent(self, hook_module):
+        assert hook_module.parse_traceparent(VALID_TRACEPARENT) == (VALID_TRACE_ID, VALID_SPAN_ID)
+
+    def test_uppercase_and_whitespace_are_normalized(self, hook_module):
+        assert hook_module.parse_traceparent(f"  {VALID_TRACEPARENT.upper()}  ") == (
+            VALID_TRACE_ID,
+            VALID_SPAN_ID,
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "garbage",
+            f"01-{VALID_TRACE_ID}-{VALID_SPAN_ID}-01",  # unsupported version
+            f"00-{VALID_TRACE_ID}-{VALID_SPAN_ID}",  # missing flags
+            f"00-{'0' * 32}-{VALID_SPAN_ID}-01",  # all-zero trace id
+            f"00-{VALID_TRACE_ID}-{'0' * 16}-01",  # all-zero span id
+            f"00-{'a' * 31}-{VALID_SPAN_ID}-01",  # short trace id
+            f"00-{VALID_TRACE_ID}-{'c' * 15}-01",  # short span id
+            f"00-{'g' * 32}-{VALID_SPAN_ID}-01",  # non-hex trace id
+        ],
+    )
+    def test_invalid_traceparent_returns_none(self, hook_module, value):
+        assert hook_module.parse_traceparent(value) is None
+
+
+class TestGetParentTraceContextFromEnv:
+    @pytest.fixture(autouse=True)
+    def clean_env(self, monkeypatch: pytest.MonkeyPatch):
+        for name in (
+            "CC_LANGFUSE_TRACEPARENT",
+            "CC_LANGFUSE_PARENT_TRACE_ID",
+            "CC_LANGFUSE_PARENT_SPAN_ID",
+        ):
+            monkeypatch.delenv(name, raising=False)
+            monkeypatch.delenv(f"CLAUDE_PLUGIN_OPTION_{name}", raising=False)
+
+    def test_unset_returns_none_pair(self, hook_module):
+        assert hook_module.get_parent_trace_context_from_env() == (None, None)
+
+    def test_traceparent_is_parsed(self, hook_module, monkeypatch):
+        monkeypatch.setenv("CC_LANGFUSE_TRACEPARENT", VALID_TRACEPARENT)
+        assert hook_module.get_parent_trace_context_from_env() == (VALID_TRACE_ID, VALID_SPAN_ID)
+
+    def test_explicit_pair_is_read(self, hook_module, monkeypatch):
+        monkeypatch.setenv("CC_LANGFUSE_PARENT_TRACE_ID", VALID_TRACE_ID.upper())
+        monkeypatch.setenv("CC_LANGFUSE_PARENT_SPAN_ID", VALID_SPAN_ID.upper())
+        assert hook_module.get_parent_trace_context_from_env() == (VALID_TRACE_ID, VALID_SPAN_ID)
+
+    def test_traceparent_wins_over_explicit_pair(self, hook_module, monkeypatch):
+        monkeypatch.setenv("CC_LANGFUSE_TRACEPARENT", VALID_TRACEPARENT)
+        monkeypatch.setenv("CC_LANGFUSE_PARENT_TRACE_ID", "1" * 32)
+        monkeypatch.setenv("CC_LANGFUSE_PARENT_SPAN_ID", "2" * 16)
+        assert hook_module.get_parent_trace_context_from_env() == (VALID_TRACE_ID, VALID_SPAN_ID)
+
+    def test_malformed_traceparent_falls_back_to_pair(self, hook_module, monkeypatch):
+        monkeypatch.setenv("CC_LANGFUSE_TRACEPARENT", "not-a-traceparent")
+        monkeypatch.setenv("CC_LANGFUSE_PARENT_TRACE_ID", VALID_TRACE_ID)
+        monkeypatch.setenv("CC_LANGFUSE_PARENT_SPAN_ID", VALID_SPAN_ID)
+        assert hook_module.get_parent_trace_context_from_env() == (VALID_TRACE_ID, VALID_SPAN_ID)
+
+    @pytest.mark.parametrize(
+        "trace_id, span_id",
+        [
+            (VALID_TRACE_ID, None),  # incomplete pair
+            (None, VALID_SPAN_ID),  # incomplete pair
+            ("nothex", VALID_SPAN_ID),
+            (VALID_TRACE_ID, "nothex"),
+            ("0" * 32, VALID_SPAN_ID),  # all-zero trace id
+            (VALID_TRACE_ID, "0" * 16),  # all-zero span id
+        ],
+    )
+    def test_invalid_pair_returns_none(self, hook_module, monkeypatch, trace_id, span_id):
+        if trace_id is not None:
+            monkeypatch.setenv("CC_LANGFUSE_PARENT_TRACE_ID", trace_id)
+        if span_id is not None:
+            monkeypatch.setenv("CC_LANGFUSE_PARENT_SPAN_ID", span_id)
+        assert hook_module.get_parent_trace_context_from_env() == (None, None)
+
+    def test_bare_traceparent_env_var_is_ignored(self, hook_module, monkeypatch):
+        # Claude Code's native OTel telemetry injects TRACEPARENT into
+        # subprocess environments; the hook must not pick it up.
+        monkeypatch.setenv("TRACEPARENT", VALID_TRACEPARENT)
+        assert hook_module.get_parent_trace_context_from_env() == (None, None)
+
+
+class TestConfigPrecedence:
+    @pytest.fixture(autouse=True)
+    def credentials(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        for name in (
+            "CC_LANGFUSE_TRACEPARENT",
+            "CC_LANGFUSE_PARENT_TRACE_ID",
+            "CC_LANGFUSE_PARENT_SPAN_ID",
+            "CC_LANGFUSE_TRACE_SEED",
+        ):
+            monkeypatch.delenv(name, raising=False)
+            monkeypatch.delenv(f"CLAUDE_PLUGIN_OPTION_{name}", raising=False)
+
+    def test_parent_context_disables_trace_seed(self, hook_module, monkeypatch):
+        monkeypatch.setenv("CC_LANGFUSE_TRACE_SEED", "my-seed")
+        monkeypatch.setenv("CC_LANGFUSE_TRACEPARENT", VALID_TRACEPARENT)
+        config = hook_module.get_langfuse_config()
+        assert config.trace_seed is None
+        assert config.parent_context == (VALID_TRACE_ID, VALID_SPAN_ID)
+
+    def test_trace_seed_stays_without_parent_context(self, hook_module, monkeypatch):
+        monkeypatch.setenv("CC_LANGFUSE_TRACE_SEED", "my-seed")
+        config = hook_module.get_langfuse_config()
+        assert config.trace_seed == "my-seed"
+        assert config.parent_context is None


### PR DESCRIPTION
## What

Adds an opt-in "attached mode": when the environment carries a parent trace context, every conversational turn joins the launching application's existing Langfuse trace, nested under the given span instead of creating separate root traces per turn.

- `CC_LANGFUSE_TRACEPARENT` (W3C trace-context format, flags ignored), or explicitly `CC_LANGFUSE_PARENT_TRACE_ID` + `CC_LANGFUSE_PARENT_SPAN_ID`
- Unset/invalid values fail open to today's standalone behavior; a present parent context takes precedence over `CC_LANGFUSE_TRACE_SEED`

> ⚠️ **Stacked on #19**

## How

- Config: `parse_traceparent()` + `get_parent_trace_context_from_env()`, strict validation (32/16 hex, non-zero), carried on `LangfuseConfig`. The bare `TRACEPARENT` variable is deliberately NOT read. Claude Code's native OTel telemetry injects it into subprocess environments and would silently reparent every trace.
- Emission: reuses the forced-trace-context plumbing from #23, extended with a real parent span id (instead of a random phantom). Attached roots set no `langfuse.internal.as_root` marker and skip `propagate_attributes` entirely — trace name, session, user, and tags are owned by the application's trace and would otherwise be overwritten server-side.
- Continuation firings (#19 resume mechanics) pin the external trace id via the stored progress.

## Tests

113 passed (94 existing + 19 new):

- `tests/unit/test_parent_trace_context.py`: traceparent parsing (valid/invalid classes), env precedence, seed precedence, bare-`TRACEPARENT` ignored
- `tests/integration/test_parent_trace_attachment.py`: turns nest under the external span, no trace-root claim, no trace-level attribute propagation, resume without reopening the root, carrier-failure fallback, unchanged behavior without env vars
