### PR TITLE
fix(hook): record usage.speed in generation metadata

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -454,6 +454,19 @@ def get_usage_details_from_row(row: Dict[str, Any]) -> Optional[Dict[str, int]]:
             details[dst] = v
     return details or None
 
+def get_speed_from_row(row: Dict[str, Any]) -> Optional[str]:
+    """Extract the Anthropic request speed ("standard"/"fast") from an assistant message."""
+    m = row.get("message")
+    if not isinstance(m, dict):
+        return None
+    u = m.get("usage")
+    if not isinstance(u, dict):
+        return None
+    speed = u.get("speed")
+    if isinstance(speed, str) and speed:
+        return speed
+    return None
+
 def parse_timestamp(value: Any) -> Optional[datetime]:
     """Parse a Claude Code jsonl row timestamp (ISO 8601 with trailing Z)."""
     if isinstance(value, dict):
@@ -1832,6 +1845,8 @@ def build_generation_kwargs(
     assistant_text, assistant_text_meta = truncate_text(assistant_text_raw)
     tool_uses = get_tool_use_blocks(get_content_from_row(assistant_message))
 
+    speed = get_speed_from_row(assistant_message)
+
     generation_kwargs: Dict[str, Any] = dict(
         model=get_model(assistant_message),
         input=build_generation_input(
@@ -1847,6 +1862,8 @@ def build_generation_kwargs(
             "tool_count": len(tool_uses),
         },
     )
+    if speed is not None:
+        generation_kwargs["metadata"]["speed"] = speed
     usage_details = get_usage_details_from_row(assistant_message)
     if usage_details is not None:
         generation_kwargs["usage_details"] = usage_details


### PR DESCRIPTION
## Summary

Claude Code records the request speed of every assistant message in the session
transcript (`usage.speed: "fast" | "standard"`; fast mode is available on Opus 4.8/4.7
and billed at a premium by Anthropic). The hook silently dropped this field, so
fast-mode requests were indistinguishable from standard ones in Langfuse (#21).

Generation observations now carry the speed verbatim in their metadata:

- `metadata.speed: "fast" | "standard"` — fast-mode requests can be filtered and
  segmented in the dashboard
- the model name is deliberately left untouched (1:1 from the transcript, no
  synthetic variants)
- transcripts without a `speed` field (older Claude Code versions) are unaffected —
  no metadata key is added

## What this does not fix

Langfuse infers cost purely by matching the model name against model definitions;
request attributes such as speed cannot influence pricing today. Fast-mode requests
therefore still receive standard-rate cost estimates. That half of #21 requires
attribute-based pricing-tier conditions in langfuse/langfuse (tracked as LFE-14297).
Once that lands, the metadata emitted by this change is exactly what the pricing
matcher will consume and no further plugin change will be needed.