### PR TITLE
fix: preserve turns across Stop hook invocations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse-observability",
   "description": "The Langfuse x Claude Code Observability Plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Langfuse"
   },

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If neither is set up, the hook exits silently — no impact on Claude Code.
 
 ## How it works
 
-A hook reads the session transcript incrementally on every turn (Stop) and at session end (SessionEnd), and emits a Langfuse trace with one span per turn, nested generations per assistant message, and child tool spans for every tool call. Token usage is captured when present.
+A hook reads the session transcript incrementally on every `Stop` event and at session end (`SessionEnd`), and emits a Langfuse trace with one span per turn, nested generations per assistant message, and child tool spans for every tool call. Token usage is captured when present. A logical turn may span multiple `Stop` events; incomplete turns are retained across hook runs and emitted when closed or when the session ends.
 
 The plugin observes only data that Claude Code exposes through hooks and transcript files.
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -271,25 +271,39 @@ class SessionState:
     offset: int = 0       # Last byte read from the transcript file.
     buffer: str = ""      # Partial JSONL line kept between hook runs.
     turn_count: int = 0   # Turns already emitted for this session.
+    # Raw rows for the trailing logical turn, which may span multiple Stop
+    # hook invocations before the next real user message closes it.
+    open_turn_rows: List[Dict[str, Any]] = field(default_factory=list)
     pending_agent_turns: List[Dict[str, Any]] = field(default_factory=list)
     # Task-notification rows whose tool_use_id could not be resolved yet
     # (task-id-only and the subagent meta.json not on disk); retried each run.
     pending_task_notifications: List[Dict[str, Any]] = field(default_factory=list)
+    # Positional anchors parallel to pending_task_notifications, used to put a
+    # resolved row back in its original place without contaminating another turn.
+    pending_task_notification_contexts: List[Dict[str, Any]] = field(default_factory=list)
 
 def get_session_state(global_state: Dict[str, Any], key: str) -> SessionState:
     s = global_state.get(key, {})
+    open_turn_rows = s.get("open_turn_rows")
+    if not isinstance(open_turn_rows, list):
+        open_turn_rows = []
     pending_agent_turns = s.get("pending_agent_turns")
     if not isinstance(pending_agent_turns, list):
         pending_agent_turns = []
     pending_task_notifications = s.get("pending_task_notifications")
     if not isinstance(pending_task_notifications, list):
         pending_task_notifications = []
+    pending_task_notification_contexts = s.get("pending_task_notification_contexts")
+    if not isinstance(pending_task_notification_contexts, list):
+        pending_task_notification_contexts = []
     return SessionState(
         offset=int(s.get("offset", 0)),
         buffer=str(s.get("buffer", "")),
         turn_count=int(s.get("turn_count", 0)),
+        open_turn_rows=open_turn_rows,
         pending_agent_turns=pending_agent_turns,
         pending_task_notifications=pending_task_notifications,
+        pending_task_notification_contexts=pending_task_notification_contexts,
     )
 
 def update_session_state(global_state: Dict[str, Any], key: str, session_state: SessionState) -> None:
@@ -297,8 +311,10 @@ def update_session_state(global_state: Dict[str, Any], key: str, session_state: 
         "offset": session_state.offset,
         "buffer": session_state.buffer,
         "turn_count": session_state.turn_count,
+        "open_turn_rows": session_state.open_turn_rows or [],
         "pending_agent_turns": session_state.pending_agent_turns or [],
         "pending_task_notifications": session_state.pending_task_notifications or [],
+        "pending_task_notification_contexts": session_state.pending_task_notification_contexts or [],
         "updated": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -463,6 +479,12 @@ def read_new_jsonl(transcript_path: Path, session_state: SessionState) -> Tuple[
             debug(f"transcript shrank ({file_size} < {session_state.offset}); restarting")
             session_state.offset = 0
             session_state.buffer = ""
+            # Rows from the old file must not be joined to the replacement
+            # transcript when its first batch is assembled.
+            session_state.open_turn_rows = []
+            session_state.pending_agent_turns = []
+            session_state.pending_task_notifications = []
+            session_state.pending_task_notification_contexts = []
         with open(transcript_path, "rb") as f:
             f.seek(session_state.offset)
             chunk = f.read()
@@ -590,6 +612,84 @@ def _find_pending_agent_turn(
             return pending_turn
     return None
 
+def _get_agent_tool_use_ids_from_row(row: Dict[str, Any]) -> List[str]:
+    tool_use_ids: List[str] = []
+    for tool_use_block in get_tool_use_blocks(get_content_from_row(row)):
+        if tool_use_block.get("name") not in ("Agent", "Task"):
+            continue
+        tool_use_id = str(tool_use_block.get("id") or "")
+        if tool_use_id:
+            tool_use_ids.append(tool_use_id)
+    return tool_use_ids
+
+def _open_turn_owns_agent_tool_use_id(
+    session_state: SessionState,
+    tool_use_id: str,
+) -> bool:
+    """Return whether the persisted open turn launched this Agent/Task.
+
+    A task-id-only notification can arrive before its subagent metadata. When
+    that metadata appears on a later hook run, the notification belongs back
+    in the open turn rather than being dropped for lack of a deferred turn.
+    """
+    for row in session_state.open_turn_rows:
+        if tool_use_id in _get_agent_tool_use_ids_from_row(row):
+            return True
+    return False
+
+def _set_row_reference(
+    context: Dict[str, Any],
+    prefix: str,
+    row: Optional[Dict[str, Any]],
+) -> None:
+    if not isinstance(row, dict):
+        return
+    row_uuid = row.get("uuid")
+    if isinstance(row_uuid, str) and row_uuid:
+        context[f"{prefix}_uuid"] = row_uuid
+    else:
+        context[f"{prefix}_row"] = row
+
+def _row_matches_reference(
+    row: Dict[str, Any],
+    context: Dict[str, Any],
+    prefix: str,
+) -> bool:
+    referenced_uuid = context.get(f"{prefix}_uuid")
+    if isinstance(referenced_uuid, str) and referenced_uuid:
+        return row.get("uuid") == referenced_uuid
+    referenced_row = context.get(f"{prefix}_row")
+    return isinstance(referenced_row, dict) and row == referenced_row
+
+def _insert_row_at_stashed_position(
+    rows: List[Dict[str, Any]],
+    row: Dict[str, Any],
+    context: Optional[Dict[str, Any]] = None,
+) -> None:
+    if any(existing_row == row for existing_row in rows):
+        return
+
+    position = context if isinstance(context, dict) else {}
+    for index, existing_row in enumerate(rows):
+        if _row_matches_reference(existing_row, position, "insert_before"):
+            rows.insert(index, row)
+            return
+    for index, existing_row in enumerate(rows):
+        if _row_matches_reference(existing_row, position, "insert_after"):
+            rows.insert(index + 1, row)
+            return
+    rows.append(row)
+
+def _row_is_retained_turn_content(row: Dict[str, Any]) -> bool:
+    if row.get("isMeta"):
+        return bool(
+            row.get("sourceToolUseID")
+            and extract_text_from_content(get_content_from_row(row))
+        )
+    if is_tool_result(row):
+        return True
+    return get_user_or_assistant_role_from_row(row) in ("user", "assistant")
+
 def resolve_deferred_agent_turns(
     rows: List[Dict[str, Any]],
     session_state: SessionState,
@@ -606,9 +706,56 @@ def resolve_deferred_agent_turns(
     """
     remaining_rows: List[Dict[str, Any]] = []
     stashed_notifications: List[Dict[str, Any]] = []
+    stashed_notification_contexts: List[Dict[str, Any]] = []
 
-    def route_to_pending_turn(pending_turn: Dict[str, Any], row: Dict[str, Any], tool_use_id: str) -> None:
-        pending_turn["rows"].append(row)
+    # Claude Code can write two representations of one completion (for
+    # example a task-id-only queue row and a user notification carrying both
+    # task-id and tool-use-id). Exact shared task ids provide authoritative
+    # correlation without guessing across parallel agents.
+    tool_use_ids_by_current_task_id: Dict[str, set[str]] = {}
+    for row in rows:
+        if not is_task_notification_row(row):
+            continue
+        task_id = get_task_id_from_task_notification(row)
+        tool_use_id = get_tool_use_id_for_task_notification(
+            row,
+            task_id_to_tool_use_id,
+        )
+        if task_id and tool_use_id:
+            tool_use_ids_by_current_task_id.setdefault(task_id, set()).add(tool_use_id)
+
+    inferred_current_tool_use_ids: Dict[int, str] = {}
+    for row_index, row in enumerate(rows):
+        if not is_task_notification_row(row):
+            continue
+        if get_tool_use_id_for_task_notification(row, task_id_to_tool_use_id):
+            continue
+        task_id = get_task_id_from_task_notification(row)
+        matching_tool_use_ids = tool_use_ids_by_current_task_id.get(task_id or "", set())
+        if len(matching_tool_use_ids) == 1:
+            inferred_current_tool_use_ids[row_index] = next(iter(matching_tool_use_ids))
+
+    inferred_stashed_tool_use_ids: Dict[int, str] = {}
+    for notification_index, notification in enumerate(
+        session_state.pending_task_notifications
+    ):
+        notification_task_id = get_task_id_from_task_notification(notification)
+        matching_tool_use_ids = tool_use_ids_by_current_task_id.get(
+            notification_task_id or "",
+            set(),
+        )
+        if len(matching_tool_use_ids) == 1:
+            inferred_stashed_tool_use_ids[notification_index] = next(
+                iter(matching_tool_use_ids)
+            )
+
+    def route_to_pending_turn(
+        pending_turn: Dict[str, Any],
+        row: Dict[str, Any],
+        tool_use_id: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        _insert_row_at_stashed_position(pending_turn["rows"], row, context)
         pending_tool_use_ids = pending_turn.get("pending_tool_use_ids")
         if isinstance(pending_tool_use_ids, list) and tool_use_id in pending_tool_use_ids:
             pending_tool_use_ids.remove(tool_use_id)
@@ -616,32 +763,153 @@ def resolve_deferred_agent_turns(
 
     # Retry stashed notifications from earlier runs first (they are older than
     # anything in the batch); their task-id may resolve now.
-    for row in session_state.pending_task_notifications:
-        tool_use_id = get_tool_use_id_for_task_notification(row, task_id_to_tool_use_id)
+    saved_contexts = session_state.pending_task_notification_contexts
+    for index, row in enumerate(session_state.pending_task_notifications):
+        context = (
+            saved_contexts[index]
+            if index < len(saved_contexts) and isinstance(saved_contexts[index], dict)
+            else {}
+        )
+        tool_use_id = (
+            get_tool_use_id_for_task_notification(row, task_id_to_tool_use_id)
+            or inferred_stashed_tool_use_ids.get(index)
+        )
         if tool_use_id is None:
             stashed_notifications.append(row)
+            stashed_notification_contexts.append(context)
             continue
         pending_turn = _find_pending_agent_turn(session_state, tool_use_id)
         if pending_turn is None:
-            debug(f"Dropping stashed task notification for {tool_use_id}: no deferred turn waits for it")
+            if _open_turn_owns_agent_tool_use_id(session_state, tool_use_id):
+                _insert_row_at_stashed_position(
+                    session_state.open_turn_rows,
+                    row,
+                    context,
+                )
+                continue
+            debug(
+                f"Dropping stashed task notification for {tool_use_id}: "
+                "no deferred or open turn waits for it"
+            )
             continue
-        route_to_pending_turn(pending_turn, row, tool_use_id)
+        route_to_pending_turn(pending_turn, row, tool_use_id, context)
 
-    for row in rows:
+    open_turn_notification_insert_index: Optional[int] = None
+    batch_agent_notification_insert_indices: Dict[str, int] = {}
+    current_batch_turn_agent_tool_use_ids: set[str] = set()
+
+    def insert_notification(index: int, row: Dict[str, Any]) -> None:
+        nonlocal open_turn_notification_insert_index
+        remaining_rows.insert(index, row)
+        if (
+            open_turn_notification_insert_index is not None
+            and open_turn_notification_insert_index >= index
+        ):
+            open_turn_notification_insert_index += 1
+        for owner_tool_use_id, owner_index in list(
+            batch_agent_notification_insert_indices.items()
+        ):
+            if owner_index >= index:
+                batch_agent_notification_insert_indices[owner_tool_use_id] = owner_index + 1
+
+    last_retained_row = (
+        session_state.open_turn_rows[-1]
+        if session_state.open_turn_rows
+        else None
+    )
+    contexts_waiting_for_next_row = [
+        index
+        for index, context in enumerate(stashed_notification_contexts)
+        if not any(key.startswith("insert_before_") for key in context)
+    ]
+
+    for row_index, row in enumerate(rows):
         if not is_task_notification_row(row):
+            if is_turn_start_row(row):
+                boundary_index = len(remaining_rows)
+                if (
+                    session_state.open_turn_rows
+                    and open_turn_notification_insert_index is None
+                ):
+                    open_turn_notification_insert_index = boundary_index
+                for tool_use_id in current_batch_turn_agent_tool_use_ids:
+                    batch_agent_notification_insert_indices[tool_use_id] = boundary_index
+                current_batch_turn_agent_tool_use_ids = set()
             remaining_rows.append(row)
+            current_batch_turn_agent_tool_use_ids.update(
+                _get_agent_tool_use_ids_from_row(row)
+            )
+            if _row_is_retained_turn_content(row):
+                for context_index in contexts_waiting_for_next_row:
+                    _set_row_reference(
+                        stashed_notification_contexts[context_index],
+                        "insert_before",
+                        row,
+                    )
+                contexts_waiting_for_next_row = []
+                last_retained_row = row
             continue
-        tool_use_id = get_tool_use_id_for_task_notification(row, task_id_to_tool_use_id)
+        previous_retained_row = last_retained_row
+        for context_index in contexts_waiting_for_next_row:
+            _set_row_reference(
+                stashed_notification_contexts[context_index],
+                "insert_before",
+                row,
+            )
+        contexts_waiting_for_next_row = []
+        tool_use_id = (
+            get_tool_use_id_for_task_notification(row, task_id_to_tool_use_id)
+            or inferred_current_tool_use_ids.get(row_index)
+        )
         if tool_use_id is None:
+            context: Dict[str, Any] = {}
+            _set_row_reference(context, "insert_after", previous_retained_row)
             stashed_notifications.append(row)
+            stashed_notification_contexts.append(context)
+            contexts_waiting_for_next_row.append(
+                len(stashed_notification_contexts) - 1
+            )
+            # A following unresolved notification anchors to this one. When
+            # both later resolve to the same turn, insertion stays stable
+            # rather than reversing notifications that shared the old anchor.
+            last_retained_row = row
             continue
+        last_retained_row = row
         pending_turn = _find_pending_agent_turn(session_state, tool_use_id)
         if pending_turn is None:
-            remaining_rows.append(row)
+            open_turn_owns_tool_use_id = _open_turn_owns_agent_tool_use_id(
+                session_state,
+                tool_use_id,
+            )
+            if (
+                open_turn_notification_insert_index is not None
+                and open_turn_owns_tool_use_id
+            ):
+                insert_notification(open_turn_notification_insert_index, row)
+                continue
+            batch_owner_index = batch_agent_notification_insert_indices.get(tool_use_id)
+            if batch_owner_index is not None:
+                insert_notification(batch_owner_index, row)
+                continue
+            if (
+                open_turn_owns_tool_use_id
+                or tool_use_id in current_batch_turn_agent_tool_use_ids
+            ):
+                remaining_rows.append(row)
+                continue
+            debug(f"Dropping task notification for {tool_use_id}: no turn owns it")
             continue
         route_to_pending_turn(pending_turn, row, tool_use_id)
 
-    session_state.pending_task_notifications = stashed_notifications[-MAX_PENDING_TASK_NOTIFICATIONS:]
+    retained_stashed_pairs = list(
+        zip(stashed_notifications, stashed_notification_contexts)
+    )[-MAX_PENDING_TASK_NOTIFICATIONS:]
+    session_state.pending_task_notifications = [
+        row for row, _ in retained_stashed_pairs
+    ]
+    session_state.pending_task_notification_contexts = [
+        context for _, context in retained_stashed_pairs
+    ]
 
     # Pop fully resolved turns in deferral (i.e. chronological) order.
     resolved_turn_row_lists: List[List[Dict[str, Any]]] = []
@@ -895,17 +1163,18 @@ def add_assistant_row(row: Dict[str, Any], state: TurnAssemblyState) -> None:
     state.current_rows.append(row)
 
 
-def build_turns(
+def is_turn_start_row(row: Dict[str, Any]) -> bool:
+    """Return whether a row starts a new conversational turn."""
+    if row.get("isMeta") or is_tool_result(row) or is_task_notification_row(row):
+        return False
+    return get_user_or_assistant_role_from_row(row) == "user"
+
+
+def assemble_closed_turns(
     rows: List[Dict[str, Any]],
     task_id_to_tool_use_id: Optional[Dict[str, str]] = None,
-) -> List[Turn]:
-    """
-    Groups incremental transcript rows into turns:
-    user (non-tool-result) -> assistant messages -> (tool_result rows, possibly interleaved)
-    Uses:
-    - assistant rows merged by message.id (all content blocks concatenated)
-    - tool results dedupe by tool_use_id (latest wins)
-    """
+) -> Tuple[List[Turn], TurnAssemblyState]:
+    """Assemble turns closed by a later user row and retain the trailing state."""
     turns: List[Turn] = []
     state = TurnAssemblyState()
 
@@ -935,9 +1204,28 @@ def build_turns(
 
         # ignore unknown rows
 
-    turn = build_turn_from_state(state)
-    if turn is not None:
-        turns.append(turn)
+    return turns, state
+
+
+def build_turns(
+    rows: List[Dict[str, Any]],
+    task_id_to_tool_use_id: Optional[Dict[str, str]] = None,
+) -> List[Turn]:
+    """
+    Groups a complete transcript row list into turns:
+    user (non-tool-result) -> assistant messages -> (tool_result rows, possibly interleaved)
+    Uses:
+    - assistant rows merged by message.id (all content blocks concatenated)
+    - tool results dedupe by tool_use_id (latest wins)
+
+    Incremental callers use assemble_closed_turns so the trailing logical turn
+    can remain open across Stop hook invocations. Full-transcript callers keep
+    the historical behavior here and receive that trailing turn immediately.
+    """
+    turns, state = assemble_closed_turns(rows, task_id_to_tool_use_id)
+    trailing_turn = build_turn_from_state(state)
+    if trailing_turn is not None:
+        turns.append(trailing_turn)
     return turns
 
 
@@ -959,18 +1247,40 @@ def get_new_turns_from_transcript(
             debug(f"Flushing {len(flushed_row_lists)} deferred agent turn(s) without task notification")
             deferred_turn_row_lists = deferred_turn_row_lists + flushed_row_lists
 
-    if flush_deferred_agent_turns and session_state.pending_task_notifications:
-        debug(f"Dropping {len(session_state.pending_task_notifications)} unresolved task notification(s) at session end")
+    if flush_deferred_agent_turns:
+        if session_state.pending_task_notifications:
+            debug(f"Dropping {len(session_state.pending_task_notifications)} unresolved task notification(s) at session end")
         session_state.pending_task_notifications = []
+        session_state.pending_task_notification_contexts = []
 
-    # Each deferred row list is a complete turn from an earlier hook run, so
-    # it is rebuilt in isolation and emitted before the current batch (its
-    # rows are always chronologically older than anything in the batch).
+    # Closed deferred turns remain isolated and precede the current/open turn
+    # chronologically.
     turns: List[Turn] = []
     for deferred_turn_rows in deferred_turn_row_lists:
         turns.extend(build_turns(deferred_turn_rows, task_id_to_tool_use_id))
-    if rows:
-        turns.extend(build_turns(rows, task_id_to_tool_use_id))
+
+    combined_rows = (
+        list(session_state.open_turn_rows)
+        + rows
+    )
+    closed_turns, trailing_state = assemble_closed_turns(
+        combined_rows,
+        task_id_to_tool_use_id,
+    )
+    turns.extend(closed_turns)
+
+    if flush_deferred_agent_turns:
+        trailing_turn = build_turn_from_state(trailing_state)
+        if trailing_turn is not None:
+            turns.append(trailing_turn)
+        session_state.open_turn_rows = []
+    elif trailing_state.current_turn_user_row is not None:
+        # Replace rather than append: current_rows already includes every raw
+        # row replayed from the previous state, so appending would duplicate
+        # content on every Stop firing.
+        session_state.open_turn_rows = list(trailing_state.current_rows)
+    else:
+        session_state.open_turn_rows = []
 
     return turns, session_state
 

--- a/tests/integration/test_deterministic_trace_ids.py
+++ b/tests/integration/test_deterministic_trace_ids.py
@@ -81,7 +81,11 @@ def test_seeded_turns_get_individually_predictable_trace_ids(
     )
 
     emitted = hook_module.emit_new_turns_from_transcript(
-        fake_langfuse, config, "session-seeded", transcript
+        fake_langfuse,
+        config,
+        "session-seeded",
+        transcript,
+        flush_deferred_agent_turns=True,
     )
 
     assert emitted == 2
@@ -115,7 +119,13 @@ def test_turn_numbers_continue_across_hook_runs(
         "public", "secret", "https://example.test", "user-1", trace_seed=seed
     )
 
-    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-seeded", transcript)
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse,
+        config,
+        "session-seeded",
+        transcript,
+        flush_deferred_agent_turns=True,
+    )
 
     # Append a third turn and run the hook again: it must derive from the
     # persisted turn_count, not restart at 1.
@@ -141,7 +151,11 @@ def test_turn_numbers_continue_across_hook_runs(
         }) + "\n")
 
     emitted = hook_module.emit_new_turns_from_transcript(
-        fake_langfuse, config, "session-seeded", transcript
+        fake_langfuse,
+        config,
+        "session-seeded",
+        transcript,
+        flush_deferred_agent_turns=True,
     )
 
     assert emitted == 1
@@ -155,7 +169,11 @@ def test_without_seed_trace_ids_stay_auto_generated(
     config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
 
     emitted = hook_module.emit_new_turns_from_transcript(
-        fake_langfuse, config, "session-seeded", transcript
+        fake_langfuse,
+        config,
+        "session-seeded",
+        transcript,
+        flush_deferred_agent_turns=True,
     )
 
     assert emitted == 2
@@ -177,7 +195,11 @@ def test_derivation_failure_falls_back_to_auto_generated_trace_id(
     monkeypatch.setattr(hook_module, "derive_turn_trace_id", _boom)
 
     emitted = hook_module.emit_new_turns_from_transcript(
-        fake_langfuse, config, "session-seeded", transcript
+        fake_langfuse,
+        config,
+        "session-seeded",
+        transcript,
+        flush_deferred_agent_turns=True,
     )
 
     assert emitted == 2
@@ -201,7 +223,11 @@ def test_forced_context_failure_falls_back_to_auto_generated_trace_id(
     monkeypatch.setattr(hook_module.otel_trace_api, "SpanContext", _boom)
 
     emitted = hook_module.emit_new_turns_from_transcript(
-        fake_langfuse, config, "session-seeded", transcript
+        fake_langfuse,
+        config,
+        "session-seeded",
+        transcript,
+        flush_deferred_agent_turns=True,
     )
 
     assert emitted == 2

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -19,11 +19,25 @@ def test_emit_new_turns_from_completed_async_agent_transcript(
         transcript,
     )
 
+    assert emitted == 0
+    state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
+    assert next(iter(state.values()))["turn_count"] == 0
+    assert next(iter(state.values()))["open_turn_rows"]
+    assert next(iter(state.values()))["pending_agent_turns"] == []
+
+    emitted = hook_module.emit_new_turns_from_transcript(
+        fake_langfuse,
+        config,
+        "session-agent-complete",
+        transcript,
+        flush_deferred_agent_turns=True,
+    )
+
     assert emitted == 1
     assert any(observation.name == "Conversational Turn" for observation in fake_langfuse.observations)
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     assert next(iter(state.values()))["turn_count"] == 1
-    assert next(iter(state.values()))["pending_agent_turns"] == []
+    assert next(iter(state.values()))["open_turn_rows"] == []
 
 
 def test_emit_new_turns_defers_async_agent_until_session_end_flush(
@@ -45,8 +59,8 @@ def test_emit_new_turns_defers_async_agent_until_session_end_flush(
     assert emitted == 0
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     pending_agent_turns = next(iter(state.values()))["pending_agent_turns"]
-    assert len(pending_agent_turns) == 1
-    assert pending_agent_turns[0]["pending_tool_use_ids"] == ["toolu_agent_deferred"]
+    assert pending_agent_turns == []
+    assert next(iter(state.values()))["open_turn_rows"]
 
     emitted = hook_module.emit_new_turns_from_transcript(
         fake_langfuse,
@@ -59,4 +73,5 @@ def test_emit_new_turns_defers_async_agent_until_session_end_flush(
     assert emitted == 1
     state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
     assert next(iter(state.values()))["turn_count"] == 1
+    assert next(iter(state.values()))["open_turn_rows"] == []
     assert next(iter(state.values()))["pending_agent_turns"] == []

--- a/tests/unit/test_async_agent_deferral.py
+++ b/tests/unit/test_async_agent_deferral.py
@@ -66,7 +66,14 @@ def make_async_launch_result_row(uuid: str, tool_use_id: str, timestamp: str) ->
     )
 
 
-def make_notification_row(uuid: str, tool_use_id: str, result: str, timestamp: str) -> dict[str, Any]:
+def make_notification_row(
+    uuid: str,
+    tool_use_id: str,
+    result: str,
+    timestamp: str,
+    task_id: str | None = None,
+) -> dict[str, Any]:
+    task_id_xml = f"<task-id>{task_id}</task-id>" if task_id else ""
     return {
         "type": "user",
         "timestamp": timestamp,
@@ -75,7 +82,7 @@ def make_notification_row(uuid: str, tool_use_id: str, result: str, timestamp: s
         "message": {
             "role": "user",
             "content": (
-                f"<task-notification><tool-use-id>{tool_use_id}</tool-use-id>"
+                f"<task-notification>{task_id_xml}<tool-use-id>{tool_use_id}</tool-use-id>"
                 f"<result>{result}</result></task-notification>"
             ),
         },
@@ -119,10 +126,26 @@ def test_completed_async_agent_turn_is_ready_to_emit(
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state, subagents)
     turns_to_emit = hook_module.get_turns_to_emit(turns, state)
 
-    assert len(turns) == 1
-    assert len(turns_to_emit) == 1
+    assert turns == []
+    assert turns_to_emit == []
+    assert state.open_turn_rows
     assert state.pending_agent_turns == []
-    result = turns[0].tool_results_by_id["toolu_agent_complete"]
+
+    turns, state = hook_module.get_new_turns_from_transcript(
+        transcript,
+        state,
+        subagents,
+        flush_deferred_agent_turns=True,
+    )
+    turns_to_emit = hook_module.get_turns_to_emit(
+        turns,
+        state,
+        flush_deferred_agent_turns=True,
+    )
+
+    assert len(turns_to_emit) == 1
+    assert state.open_turn_rows == []
+    result = turns_to_emit[0].tool_results_by_id["toolu_agent_complete"]
     assert result["final_content"] == "Subagent summary is ready."
 
 
@@ -138,8 +161,8 @@ def test_uncompleted_async_agent_turn_is_deferred_until_flush(
     turns_to_emit = hook_module.get_turns_to_emit(turns, state)
 
     assert turns_to_emit == []
-    assert len(state.pending_agent_turns) == 1
-    assert state.pending_agent_turns[0]["pending_tool_use_ids"] == ["toolu_agent_deferred"]
+    assert state.open_turn_rows
+    assert state.pending_agent_turns == []
 
     flushed_turns, state = hook_module.get_new_turns_from_transcript(
         transcript,
@@ -192,6 +215,46 @@ def test_turn_waiting_on_multiple_agents_resolves_only_after_all_notifications(h
     assert len(resolved) == 1
     assert resolved[0] == deferred_rows
     assert resolved[0][-2:] == [first_notification, second_notification]
+
+
+def test_adjacent_parallel_agent_notifications_are_not_guessed_to_match(hook_module):
+    deferred_rows = launch_turn_rows("toolu_agent_a")
+    state = hook_module.SessionState(
+        pending_agent_turns=[
+            {
+                "pending_tool_use_ids": ["toolu_agent_a", "toolu_agent_b"],
+                "rows": deferred_rows,
+            },
+        ],
+    )
+    notification_a_without_mapping = make_task_id_notification_row(
+        "notif-a", "agent-a", "Result A", "2026-01-01T00:01:00.000Z"
+    )
+    notification_b = make_notification_row(
+        "notif-b", "toolu_agent_b", "Result B", "2026-01-01T00:01:01.000Z"
+    )
+
+    resolved, remaining = hook_module.resolve_deferred_agent_turns(
+        [notification_a_without_mapping, notification_b],
+        state,
+    )
+
+    assert resolved == []
+    assert remaining == []
+    assert state.pending_agent_turns[0]["pending_tool_use_ids"] == ["toolu_agent_a"]
+    assert state.pending_agent_turns[0]["rows"][-1] == notification_b
+    assert state.pending_task_notifications == [notification_a_without_mapping]
+
+    resolved, remaining = hook_module.resolve_deferred_agent_turns(
+        [],
+        state,
+        {"agent-a": "toolu_agent_a"},
+    )
+
+    assert remaining == []
+    assert state.pending_agent_turns == []
+    assert len(resolved) == 1
+    assert resolved[0][-2:] == [notification_a_without_mapping, notification_b]
 
 
 def test_duplicate_notifications_for_same_agent_are_routed_to_the_deferred_turn(hook_module):
@@ -303,11 +366,12 @@ def test_mid_turn_notification_does_not_corrupt_the_surrounding_turn(hook_module
     transcript = tmp_path / "transcript.jsonl"
     state = hook_module.SessionState()
 
-    # Hook run 1: turn 1 launches an async agent and ends -> deferred.
+    # Hook run 1: turn 1 launches an async agent and remains open.
     append_jsonl(transcript, launch_turn_rows("toolu_bg"))
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
     assert hook_module.get_turns_to_emit(turns, state) == []
-    assert len(state.pending_agent_turns) == 1
+    assert state.open_turn_rows
+    assert state.pending_agent_turns == []
 
     # Hook run 2: turn 2 is mid-flight when the notification lands between
     # two of its assistant messages (the normal real-world shape).
@@ -329,14 +393,23 @@ def test_mid_turn_notification_does_not_corrupt_the_surrounding_turn(hook_module
     turns_to_emit = hook_module.get_turns_to_emit(turns, state)
 
     assert state.pending_agent_turns == []
-    assert len(turns_to_emit) == 2
+    assert len(turns_to_emit) == 1
 
-    resolved_turn, current_turn = turns_to_emit
-    # The deferred turn is rebuilt intact, with the notification result attached.
+    resolved_turn = turns_to_emit[0]
+    # The older turn is rebuilt intact, with the notification result attached.
     assert resolved_turn.user_msg["uuid"] == "user-1"
     assert [m["message"]["id"] for m in resolved_turn.assistant_msgs] == ["msg-1", "msg-2"]
     assert resolved_turn.tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
-    # The current turn keeps ALL of its assistant messages.
+
+    # The current turn stays open until the next real user row, then keeps ALL
+    # of the assistant messages that surrounded the notification.
+    append_jsonl(transcript, [
+        make_user_row("user-3", "One more question.", "2026-01-01T00:05:04.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    turns_to_emit = hook_module.get_turns_to_emit(turns, state)
+    assert len(turns_to_emit) == 1
+    current_turn = turns_to_emit[0]
     assert current_turn.user_msg["uuid"] == "user-2"
     assert [m["message"]["id"] for m in current_turn.assistant_msgs] == ["msg-3", "msg-4"]
 
@@ -363,12 +436,573 @@ def test_notification_before_first_assistant_row_does_not_drop_the_turn(hook_mod
     turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
     turns_to_emit = hook_module.get_turns_to_emit(turns, state)
 
-    assert len(turns_to_emit) == 2
-    resolved_turn, current_turn = turns_to_emit
+    assert len(turns_to_emit) == 1
+    resolved_turn = turns_to_emit[0]
     assert resolved_turn.user_msg["uuid"] == "user-1"
     assert resolved_turn.tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
+
+    append_jsonl(transcript, [
+        make_user_row("user-3", "Another question.", "2026-01-01T00:05:03.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    turns_to_emit = hook_module.get_turns_to_emit(turns, state)
+    assert len(turns_to_emit) == 1
+    current_turn = turns_to_emit[0]
     assert current_turn.user_msg["uuid"] == "user-2"
     assert [m["message"]["id"] for m in current_turn.assistant_msgs] == ["msg-3"]
+
+
+def test_closed_deferred_agent_and_open_current_turn_coexist(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    # The next human row closes turn 1 before its async notification, so the
+    # existing agent-specific mechanism defers it while turn 2 stays open.
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Work on turn two.", "2026-01-01T00:05:00.000Z"),
+        make_assistant_row(
+            "assistant-3", "msg-3", [{"type": "text", "text": "Turn two starts."}],
+            "2026-01-01T00:05:01.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+    assert len(state.pending_agent_turns) == 1
+    assert state.open_turn_rows
+
+    # The old turn resolves between ordinary continuation rows for the open
+    # current turn. They must remain isolated from each other.
+    append_jsonl(transcript, [
+        make_assistant_row(
+            "assistant-4", "msg-4", [{"type": "text", "text": "Still on turn two."}],
+            "2026-01-01T00:05:02.000Z",
+        ),
+        make_notification_row(
+            "notif-bg", "toolu_bg", "Background result.", "2026-01-01T00:05:03.000Z"
+        ),
+        make_assistant_row(
+            "assistant-5", "msg-5", [{"type": "text", "text": "Turn two continues."}],
+            "2026-01-01T00:05:04.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    assert emitted[0].user_msg["uuid"] == "user-1"
+    assert emitted[0].tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
+    assert state.pending_agent_turns == []
+    all_emitted = list(emitted)
+
+    append_jsonl(transcript, [
+        make_user_row("user-3", "Close turn two.", "2026-01-01T00:05:05.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    assert emitted[0].user_msg["uuid"] == "user-2"
+    assert [row["message"]["id"] for row in emitted[0].assistant_msgs] == [
+        "msg-3", "msg-4", "msg-5",
+    ]
+    all_emitted.extend(emitted)
+    emitted_row_uuid_sets = [
+        {row["uuid"] for row in turn.rows if row.get("uuid")}
+        for turn in all_emitted
+    ]
+    assert emitted_row_uuid_sets[0].isdisjoint(emitted_row_uuid_sets[1])
+    all_row_uuids = [
+        row["uuid"]
+        for turn in all_emitted
+        for row in turn.rows
+        if row.get("uuid")
+    ]
+    assert len(all_row_uuids) == len(set(all_row_uuids))
+
+
+def test_same_batch_notification_is_routed_before_its_later_user_boundary(
+    hook_module,
+    tmp_path,
+):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+    append_jsonl(transcript, [
+        *launch_turn_rows("toolu_bg"),
+        make_assistant_row(
+            "assistant-between", "msg-between",
+            [{"type": "text", "text": "Continuation before the next prompt."}],
+            "2026-01-01T00:04:59.000Z",
+        ),
+        make_user_row("user-2", "Second prompt.", "2026-01-01T00:05:00.000Z"),
+        make_notification_row(
+            "notif-bg", "toolu_bg", "Background result.", "2026-01-01T00:05:01.000Z"
+        ),
+        make_assistant_row(
+            "assistant-3", "msg-3", [{"type": "text", "text": "Second answer."}],
+            "2026-01-01T00:05:02.000Z",
+        ),
+    ])
+
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    first_turn = emitted[0]
+    assert first_turn.user_msg["uuid"] == "user-1"
+    assert first_turn.tool_results_by_id["toolu_bg"]["final_content"] == "Background result."
+    assert [row["uuid"] for row in first_turn.rows if row.get("uuid")] == [
+        "user-1",
+        "assistant-1",
+        "tool-result-1",
+        "assistant-2",
+        "assistant-between",
+        "notif-bg",
+    ]
+    assert state.pending_agent_turns == []
+
+    append_jsonl(transcript, [
+        make_user_row("user-3", "Third prompt.", "2026-01-01T00:05:03.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    assert emitted[0].user_msg["uuid"] == "user-2"
+    assert [row["message"]["id"] for row in emitted[0].assistant_msgs] == ["msg-3"]
+    assert "toolu_bg" not in emitted[0].tool_results_by_id
+
+
+def test_late_duplicate_notification_does_not_contaminate_unrelated_open_turn(
+    hook_module,
+    tmp_path,
+):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_notification_row(
+            "notif-1", "toolu_bg", "Background result.", "2026-01-01T00:04:59.000Z"
+        ),
+        make_user_row("user-2", "Second prompt.", "2026-01-01T00:05:00.000Z"),
+        make_assistant_row(
+            "assistant-3", "msg-3", [{"type": "text", "text": "Second answer."}],
+            "2026-01-01T00:05:01.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+    assert len(emitted) == 1
+    assert emitted[0].user_msg["uuid"] == "user-1"
+
+    append_jsonl(transcript, [
+        make_notification_row(
+            "notif-2", "toolu_bg", "Duplicate result.", "2026-01-01T00:05:02.000Z"
+        ),
+        make_user_row("user-3", "Third prompt.", "2026-01-01T00:05:03.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    assert emitted[0].user_msg["uuid"] == "user-2"
+    assert all(row.get("uuid") != "notif-2" for row in emitted[0].rows)
+    assert "toolu_bg" not in emitted[0].tool_results_by_id
+
+
+def test_ordinary_turn_spanning_multiple_stop_firings_is_not_dropped(hook_module, tmp_path):
+    """A turn with no async agent involved at all can still legitimately span
+    more than one Stop firing. None of its content should be lost."""
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, [
+        make_user_row(
+            "user-1",
+            "Do the first thing, then the second thing.",
+            "2026-01-01T00:00:00.000Z",
+        ),
+        make_assistant_row(
+            "assistant-1",
+            "msg-1",
+            [{"type": "tool_use", "id": "toolu_1", "name": "Bash",
+              "input": {"command": "echo one"}}],
+            "2026-01-01T00:00:01.000Z",
+        ),
+        make_agent_result_row(
+            "tool-result-1", "toolu_1", "one", "2026-01-01T00:00:02.000Z"
+        ),
+        make_assistant_row(
+            "assistant-2",
+            "msg-2",
+            [{"type": "text", "text": "Done with the first thing."}],
+            "2026-01-01T00:00:03.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_assistant_row(
+            "assistant-3",
+            "msg-3",
+            [{"type": "tool_use", "id": "toolu_2", "name": "Bash",
+              "input": {"command": "echo two"}}],
+            "2026-01-01T00:00:04.000Z",
+        ),
+        make_agent_result_row(
+            "tool-result-2", "toolu_2", "two", "2026-01-01T00:00:05.000Z"
+        ),
+        make_assistant_row(
+            "assistant-4",
+            "msg-4",
+            [{"type": "text", "text": "Done with the second thing too."}],
+            "2026-01-01T00:00:06.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_user_row(
+            "user-2", "Great, now do a third thing.", "2026-01-01T00:00:07.000Z"
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    turns_to_emit = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(turns_to_emit) == 1
+    closed_turn = turns_to_emit[0]
+    assert closed_turn.user_msg["uuid"] == "user-1"
+    assert [m["message"]["id"] for m in closed_turn.assistant_msgs] == [
+        "msg-1", "msg-2", "msg-3", "msg-4",
+    ]
+    assert closed_turn.tool_results_by_id["toolu_1"]["content"] == [
+        {"type": "text", "text": "one"},
+    ]
+    assert closed_turn.tool_results_by_id["toolu_2"]["content"] == [
+        {"type": "text", "text": "two"},
+    ]
+    row_uuids = [row["uuid"] for row in closed_turn.rows if row.get("uuid")]
+    assert len(row_uuids) == len(set(row_uuids))
+
+
+def test_ordinary_turn_accumulates_across_four_stop_firings(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+    emitted = []
+
+    batches = [
+        [
+            make_user_row("user-1", "Keep working.", "2026-01-01T00:00:00.000Z"),
+            make_assistant_row(
+                "assistant-1", "msg-1", [{"type": "text", "text": "Step one."}],
+                "2026-01-01T00:00:01.000Z",
+            ),
+        ],
+        [
+            make_assistant_row(
+                "assistant-2", "msg-2",
+                [{"type": "tool_use", "id": "toolu_many", "name": "Bash", "input": {}}],
+                "2026-01-01T00:00:02.000Z",
+            ),
+        ],
+        [
+            make_agent_result_row(
+                "tool-result-many", "toolu_many", "result", "2026-01-01T00:00:03.000Z"
+            ),
+            make_assistant_row(
+                "assistant-3", "msg-3", [{"type": "text", "text": "Step three."}],
+                "2026-01-01T00:00:04.000Z",
+            ),
+        ],
+        [
+            make_assistant_row(
+                "assistant-4", "msg-4", [{"type": "text", "text": "Step four."}],
+                "2026-01-01T00:00:05.000Z",
+            ),
+        ],
+    ]
+
+    for batch in batches:
+        append_jsonl(transcript, batch)
+        turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+        emitted.extend(hook_module.get_turns_to_emit(turns, state))
+        assert emitted == []
+
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Now stop.", "2026-01-01T00:00:06.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted.extend(hook_module.get_turns_to_emit(turns, state))
+
+    assert [turn.user_msg["uuid"] for turn in emitted] == ["user-1"]
+    closed_turn = emitted[0]
+    assert [row["message"]["id"] for row in closed_turn.assistant_msgs] == [
+        "msg-1", "msg-2", "msg-3", "msg-4",
+    ]
+    assert closed_turn.tool_results_by_id["toolu_many"]["content"] == [
+        {"type": "text", "text": "result"},
+    ]
+    row_uuids = [row["uuid"] for row in closed_turn.rows if row.get("uuid")]
+    assert len(row_uuids) == len(set(row_uuids))
+
+
+def test_async_resolution_then_ordinary_continuation_stays_in_one_open_turn(
+    hook_module,
+    tmp_path,
+):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, [
+        make_user_row("user-1", "Do all the work.", "2026-01-01T00:00:00.000Z"),
+        make_assistant_row(
+            "assistant-1", "msg-1",
+            [{"type": "tool_use", "id": "toolu_sync", "name": "Bash", "input": {}}],
+            "2026-01-01T00:00:01.000Z",
+        ),
+        make_agent_result_row(
+            "tool-result-sync", "toolu_sync", "sync", "2026-01-01T00:00:02.000Z"
+        ),
+        make_assistant_row(
+            "assistant-2", "msg-2", [{"type": "text", "text": "First part done."}],
+            "2026-01-01T00:00:03.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_assistant_row(
+            "assistant-3", "msg-3",
+            [{"type": "tool_use", "id": "toolu_bg", "name": "Agent", "input": {}}],
+            "2026-01-01T00:00:04.000Z",
+        ),
+        make_async_launch_result_row(
+            "tool-result-bg", "toolu_bg", "2026-01-01T00:00:05.000Z"
+        ),
+        make_assistant_row(
+            "assistant-4", "msg-4", [{"type": "text", "text": "Agent is running."}],
+            "2026-01-01T00:00:06.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_notification_row(
+            "notif-bg", "toolu_bg", "Agent result.", "2026-01-01T00:00:07.000Z"
+        ),
+        make_assistant_row(
+            "assistant-5", "msg-5",
+            [{"type": "tool_use", "id": "toolu_after", "name": "Bash", "input": {}}],
+            "2026-01-01T00:00:08.000Z",
+        ),
+        make_agent_result_row(
+            "tool-result-after", "toolu_after", "after", "2026-01-01T00:00:09.000Z"
+        ),
+        make_assistant_row(
+            "assistant-6", "msg-6", [{"type": "text", "text": "Everything is done."}],
+            "2026-01-01T00:00:10.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Thanks.", "2026-01-01T00:00:11.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    turn = emitted[0]
+    assert turn.user_msg["uuid"] == "user-1"
+    assert [row["message"]["id"] for row in turn.assistant_msgs] == [
+        "msg-1", "msg-2", "msg-3", "msg-4", "msg-5", "msg-6",
+    ]
+    assert turn.tool_results_by_id["toolu_bg"]["final_content"] == "Agent result."
+    assert turn.tool_results_by_id["toolu_after"]["content"] == [
+        {"type": "text", "text": "after"},
+    ]
+    row_uuids = [row["uuid"] for row in turn.rows if row.get("uuid")]
+    assert len(row_uuids) == len(set(row_uuids))
+
+
+def test_user_only_tail_is_retained_until_its_first_assistant_row(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+    append_jsonl(transcript, [
+        make_user_row("user-1", "Wait for permission.", "2026-01-01T00:00:00.000Z"),
+    ])
+
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+    assert [row["uuid"] for row in state.open_turn_rows] == ["user-1"]
+
+    append_jsonl(transcript, [
+        make_assistant_row(
+            "assistant-1", "msg-1", [{"type": "text", "text": "Permission granted."}],
+            "2026-01-01T00:00:01.000Z",
+        ),
+        make_user_row("user-2", "Continue.", "2026-01-01T00:00:02.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    assert emitted[0].user_msg["uuid"] == "user-1"
+    assert [row["message"]["id"] for row in emitted[0].assistant_msgs] == ["msg-1"]
+
+
+def test_session_end_flushes_an_open_ordinary_turn_exactly_once(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+    append_jsonl(transcript, [
+        make_user_row("user-1", "Finish before exit.", "2026-01-01T00:00:00.000Z"),
+        make_assistant_row(
+            "assistant-1", "msg-1",
+            [{"type": "tool_use", "id": "toolu_exit", "name": "Bash", "input": {}}],
+            "2026-01-01T00:00:01.000Z",
+        ),
+        make_agent_result_row(
+            "tool-result-exit", "toolu_exit", "done", "2026-01-01T00:00:02.000Z"
+        ),
+        make_assistant_row(
+            "assistant-2", "msg-2", [{"type": "text", "text": "Finished."}],
+            "2026-01-01T00:00:03.000Z",
+        ),
+    ])
+
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+    assert state.open_turn_rows
+
+    turns, state = hook_module.get_new_turns_from_transcript(
+        transcript, state, flush_deferred_agent_turns=True
+    )
+    emitted = hook_module.get_turns_to_emit(
+        turns, state, flush_deferred_agent_turns=True
+    )
+    assert len(emitted) == 1
+    assert [row["message"]["id"] for row in emitted[0].assistant_msgs] == ["msg-1", "msg-2"]
+    assert emitted[0].tool_results_by_id["toolu_exit"]["content"] == [
+        {"type": "text", "text": "done"},
+    ]
+    assert state.open_turn_rows == []
+
+    turns, state = hook_module.get_new_turns_from_transcript(
+        transcript, state, flush_deferred_agent_turns=True
+    )
+    assert hook_module.get_turns_to_emit(
+        turns, state, flush_deferred_agent_turns=True
+    ) == []
+
+
+def test_disconnected_human_row_cannot_erase_the_accumulated_open_turn(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+    first_batch = [
+        make_user_row("user-1", "Work on the real branch.", "2026-01-01T00:00:00.000Z"),
+        make_assistant_row(
+            "assistant-1", "msg-1",
+            [{"type": "tool_use", "id": "toolu_real", "name": "Bash", "input": {}}],
+            "2026-01-01T00:00:01.000Z",
+        ),
+        make_agent_result_row(
+            "tool-result-real", "toolu_real", "real", "2026-01-01T00:00:02.000Z"
+        ),
+        make_assistant_row(
+            "assistant-2", "msg-2", [{"type": "text", "text": "Captured prefix."}],
+            "2026-01-01T00:00:03.000Z",
+        ),
+    ]
+    first_batch[1]["parentUuid"] = "user-1"
+    first_batch[2]["parentUuid"] = "assistant-1"
+    first_batch[3]["parentUuid"] = "tool-result-real"
+    append_jsonl(transcript, first_batch)
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    stray = make_user_row(
+        "user-foreign", "Unrelated branch.", "2026-01-01T00:00:04.000Z"
+    )
+    stray["parentUuid"] = "foreign-parent"
+    continuation = make_assistant_row(
+        "assistant-3", "msg-3", [{"type": "text", "text": "Later content."}],
+        "2026-01-01T00:00:05.000Z",
+    )
+    continuation["parentUuid"] = "assistant-2"
+    append_jsonl(transcript, [stray, continuation])
+
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    # The conservative fallback is allowed to close the real turn early, but
+    # the disconnected row must never erase or shorten its captured prefix.
+    assert len(emitted) == 1
+    real_turn = emitted[0]
+    assert real_turn.user_msg["uuid"] == "user-1"
+    assert [row["message"]["id"] for row in real_turn.assistant_msgs] == ["msg-1", "msg-2"]
+    assert real_turn.tool_results_by_id["toolu_real"]["content"] == [
+        {"type": "text", "text": "real"},
+    ]
+    row_uuids = [row["uuid"] for row in real_turn.rows if row.get("uuid")]
+    assert len(row_uuids) == len(set(row_uuids))
+
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Back to the real branch.", "2026-01-01T00:00:06.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    stray_turns = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(stray_turns) == 1
+    assert stray_turns[0].user_msg["uuid"] == "user-foreign"
+    assert [row["message"]["id"] for row in stray_turns[0].assistant_msgs] == ["msg-3"]
+    stray_row_uuids = {
+        row["uuid"] for row in stray_turns[0].rows if row.get("uuid")
+    }
+    assert set(row_uuids).isdisjoint(stray_row_uuids)
+
+
+def test_open_turn_state_is_backward_compatible_and_round_trips(hook_module):
+    old_global_state = {
+        "old": {
+            "offset": 12,
+            "buffer": "",
+            "turn_count": 3,
+            "pending_agent_turns": [],
+            "pending_task_notifications": [],
+        },
+        "malformed": {
+            "open_turn_rows": {"not": "a list"},
+            "pending_task_notification_contexts": {"not": "a list"},
+        },
+    }
+
+    assert hook_module.get_session_state(old_global_state, "old").open_turn_rows == []
+    assert hook_module.get_session_state(old_global_state, "malformed").open_turn_rows == []
+    assert hook_module.get_session_state(
+        old_global_state, "old"
+    ).pending_task_notification_contexts == []
+    assert hook_module.get_session_state(
+        old_global_state, "malformed"
+    ).pending_task_notification_contexts == []
+
+    open_row = make_user_row("user-1", "Still open.", "2026-01-01T00:00:00.000Z")
+    state = hook_module.SessionState(open_turn_rows=[open_row])
+    serialized: dict[str, Any] = {}
+    hook_module.update_session_state(serialized, "key", state)
+
+    assert hook_module.get_session_state(serialized, "key").open_turn_rows == [open_row]
 
 
 def sync_agent_turn_rows(tool_use_id: str = "toolu_sync", result_text: str = "Here is the final research report.") -> list[dict[str, Any]]:
@@ -511,11 +1145,17 @@ def test_unresolvable_notification_is_stashed_and_resolved_when_meta_appears(hoo
 
     append_jsonl(transcript, launch_turn_rows("toolu_bg"))
     assert run() == []
-    assert len(state.pending_agent_turns) == 1
+    assert state.open_turn_rows
+    assert state.pending_agent_turns == []
 
-    # Notification lands alone in the next batch; no meta.json on disk yet.
+    # The unresolved notification and later continuation retain their raw-row
+    # order while no meta.json exists yet.
     append_jsonl(transcript, [
         make_task_id_notification_row("n1", "agent-late", "Late result.", "2026-01-01T00:01:00.000Z"),
+        make_assistant_row(
+            "assistant-wait", "msg-wait", [{"type": "text", "text": "Still waiting."}],
+            "2026-01-01T00:01:01.000Z",
+        ),
     ])
     assert run() == []
     assert len(state.pending_task_notifications) == 1
@@ -528,10 +1168,200 @@ def test_unresolvable_notification_is_stashed_and_resolved_when_meta_appears(hoo
                            [{"type": "text", "text": "Answer."}], "2026-01-01T00:02:01.000Z"),
     ])
     emitted = run()
+    append_jsonl(transcript, [
+        make_user_row("user-3", "Final question.", "2026-01-01T00:02:02.000Z"),
+    ])
+    emitted += run()
 
     assert [t.user_msg["uuid"] for t in emitted] == ["user-1", "user-2"]
     assert emitted[0].tool_results_by_id["toolu_bg"]["final_content"] == "Late result."
+    emitted_user_1_uuids = [row["uuid"] for row in emitted[0].rows if row.get("uuid")]
+    assert emitted_user_1_uuids.index("n1") < emitted_user_1_uuids.index("assistant-wait")
     assert state.pending_agent_turns == []
+    assert state.pending_task_notifications == []
+
+
+def test_stashed_notification_resolves_after_boundary_without_duplication(
+    hook_module,
+    tmp_path,
+):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    notification = make_task_id_notification_row(
+        "n1", "agent-late", "Late result.", "2026-01-01T00:01:00.000Z"
+    )
+    append_jsonl(transcript, [notification])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+    assert len(state.pending_task_notifications) == 1
+
+    # The next prompt closes the turn while metadata is still absent. The
+    # unresolved row stays only in the notification stash until ownership is known.
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Next question.", "2026-01-01T00:02:00.000Z"),
+        make_assistant_row(
+            "assistant-3", "msg-3", [{"type": "text", "text": "Next answer."}],
+            "2026-01-01T00:02:01.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+    assert len(state.pending_agent_turns) == 1
+    assert [row.get("uuid") for row in state.pending_agent_turns[0]["rows"]].count("n1") == 0
+
+    write_subagent_meta(transcript, "agent-late", "toolu_bg")
+    sub_map = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state, sub_map)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    assert emitted[0].tool_results_by_id["toolu_bg"]["final_content"] == "Late result."
+    assert [row.get("uuid") for row in emitted[0].rows].count("n1") == 1
+    assert state.pending_agent_turns == []
+    assert state.pending_task_notifications == []
+
+
+def test_unresolved_notification_after_boundary_never_leaks_into_both_turns(
+    hook_module,
+    tmp_path,
+):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    notification = make_task_id_notification_row(
+        "n1", "agent-late", "Late result.", "2026-01-01T00:05:01.000Z"
+    )
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Second question.", "2026-01-01T00:05:00.000Z"),
+        notification,
+        make_assistant_row(
+            "assistant-3", "msg-3", [{"type": "text", "text": "Second answer."}],
+            "2026-01-01T00:05:02.000Z",
+        ),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+    assert len(state.pending_agent_turns) == 1
+    assert all(row.get("uuid") != "n1" for row in state.open_turn_rows)
+
+    # Turn 2 can close and emit before ownership metadata appears; it must not
+    # contain the unresolved row that ultimately belongs to turn 1.
+    append_jsonl(transcript, [
+        make_user_row("user-3", "Third question.", "2026-01-01T00:05:03.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted_turn_2 = hook_module.get_turns_to_emit(turns, state)
+    assert len(emitted_turn_2) == 1
+    assert emitted_turn_2[0].user_msg["uuid"] == "user-2"
+    assert all(row.get("uuid") != "n1" for row in emitted_turn_2[0].rows)
+
+    write_subagent_meta(transcript, "agent-late", "toolu_bg")
+    sub_map = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state, sub_map)
+    emitted_turn_1 = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted_turn_1) == 1
+    assert emitted_turn_1[0].user_msg["uuid"] == "user-1"
+    assert emitted_turn_1[0].tool_results_by_id["toolu_bg"]["final_content"] == "Late result."
+    assert [row.get("uuid") for row in emitted_turn_1[0].rows].count("n1") == 1
+    turn_1_uuids = {row.get("uuid") for row in emitted_turn_1[0].rows if row.get("uuid")}
+    turn_2_uuids = {row.get("uuid") for row in emitted_turn_2[0].rows if row.get("uuid")}
+    assert turn_1_uuids.isdisjoint(turn_2_uuids)
+
+
+def test_multiple_stashed_notifications_keep_order_at_open_turn_tail(
+    hook_module,
+    tmp_path,
+):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    notifications = [
+        make_task_id_notification_row(
+            "n1", "agent-late", "First result.", "2026-01-01T00:01:00.000Z"
+        ),
+        make_task_id_notification_row(
+            "n2", "agent-late", "Final result.", "2026-01-01T00:01:01.000Z"
+        ),
+    ]
+    append_jsonl(transcript, notifications)
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+    assert len(state.pending_task_notifications) == 2
+
+    write_subagent_meta(transcript, "agent-late", "toolu_bg")
+    sub_map = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state, sub_map)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_user_row("user-2", "Next question.", "2026-01-01T00:02:00.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state, sub_map)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    notification_uuids = [
+        row.get("uuid")
+        for row in emitted[0].rows
+        if row.get("uuid") in {"n1", "n2"}
+    ]
+    assert notification_uuids == ["n1", "n2"]
+    assert emitted[0].tool_results_by_id["toolu_bg"]["final_content"] == "Final result."
+
+
+def test_adjacent_unresolved_notification_is_attributed_before_resolvable_duplicate(
+    hook_module,
+    tmp_path,
+):
+    transcript = tmp_path / "transcript.jsonl"
+    state = hook_module.SessionState()
+
+    append_jsonl(transcript, launch_turn_rows("toolu_bg"))
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    assert hook_module.get_turns_to_emit(turns, state) == []
+
+    append_jsonl(transcript, [
+        make_task_id_notification_row(
+            "n1", "agent-late", "First result.", "2026-01-01T00:01:00.000Z"
+        ),
+        make_notification_row(
+            "n2",
+            "toolu_bg",
+            "Final result.",
+            "2026-01-01T00:01:01.000Z",
+            task_id="agent-late",
+        ),
+        make_assistant_row(
+            "assistant-after", "msg-after", [{"type": "text", "text": "After both."}],
+            "2026-01-01T00:01:02.000Z",
+        ),
+        make_user_row("user-2", "Next question.", "2026-01-01T00:02:00.000Z"),
+    ])
+    turns, state = hook_module.get_new_turns_from_transcript(transcript, state)
+    emitted = hook_module.get_turns_to_emit(turns, state)
+
+    assert len(emitted) == 1
+    relevant_uuids = [
+        row.get("uuid")
+        for row in emitted[0].rows
+        if row.get("uuid") in {"n1", "n2", "assistant-after"}
+    ]
+    assert relevant_uuids == ["n1", "n2", "assistant-after"]
+    assert emitted[0].tool_results_by_id["toolu_bg"]["final_content"] == "Final result."
     assert state.pending_task_notifications == []
 
 
@@ -589,10 +1419,15 @@ def test_stashed_notifications_are_bounded(hook_module):
 
 def test_session_state_round_trips_stashed_notifications(hook_module):
     notification = make_notification_row("n1", "toolu_bg", "Result", "2026-01-01T00:01:00.000Z")
-    state = hook_module.SessionState(pending_task_notifications=[notification])
+    context = {"insert_after_uuid": "assistant-1", "insert_before_uuid": "assistant-2"}
+    state = hook_module.SessionState(
+        pending_task_notifications=[notification],
+        pending_task_notification_contexts=[context],
+    )
     global_state: dict[str, Any] = {}
 
     hook_module.update_session_state(global_state, "key", state)
     restored = hook_module.get_session_state(global_state, "key")
 
     assert restored.pending_task_notifications == [notification]
+    assert restored.pending_task_notification_contexts == [context]

--- a/tests/unit/test_transcript_reader.py
+++ b/tests/unit/test_transcript_reader.py
@@ -50,8 +50,16 @@ def test_read_new_jsonl_restarts_when_file_shrinks(hook_module, tmp_path):
     state = hook_module.SessionState()
     rows, state = hook_module.read_new_jsonl(transcript, state)
     assert rows == [first]
+    state.open_turn_rows = [first]
+    state.pending_agent_turns = [{"rows": [first]}]
+    state.pending_task_notifications = [first]
+    state.pending_task_notification_contexts = [{"insert_after_uuid": "old"}]
 
     transcript.write_text(json.dumps(second) + "\n", encoding="utf-8")
     rows, state = hook_module.read_new_jsonl(transcript, state)
     assert rows == [second]
     assert state.offset == transcript.stat().st_size
+    assert state.open_turn_rows == []
+    assert state.pending_agent_turns == []
+    assert state.pending_task_notifications == []
+    assert state.pending_task_notification_contexts == []


### PR DESCRIPTION
## Summary

- persist the trailing logical turn across any number of incremental `Stop` hook runs
- replay retained rows exactly once and in order when continuation bytes arrive
- keep the generalized open-turn state compatible with the existing async Agent/Task deferral flow
- flush an ordinary open turn exactly once at `SessionEnd`
- defensively preserve already-assembled content when an unexpected human-origin row appears
- tolerate state files written before the new fields existed
- bump the plugin version to `1.0.1` and document multi-`Stop` turn assembly

## Root cause

`read_new_jsonl` correctly advances the transcript byte offset, but each call to `build_turns` previously started with a fresh `TurnAssemblyState`. A later batch containing only assistant/tool continuation rows therefore had no user row to attach them to and silently discarded them. `pending_agent_turns` covered only the narrower unresolved async-agent case.

The incremental path now retains the trailing raw rows in session state and prepends them to the next batch. Only turns closed by a later real user row are emitted during `Stop`; the remaining tail is emitted at `SessionEnd`. Complete-transcript callers keep the existing immediate-tail behavior.

Task notifications are routed only when a tool/task mapping proves ownership. Unresolvable notifications remain stashed instead of being guessed across parallel agents, and late duplicates cannot contaminate a newer turn.

## Tests

The added regressions cover:

- an ordinary turn split across two and four `Stop` firings
- async notification resolution followed by more ordinary continuation
- closed deferred-agent and newer open turns coexisting
- same-batch, delayed-metadata, duplicate, and parallel-agent notification routing
- raw-row ordering and uniqueness across emitted turns
- `SessionEnd` flushing an ordinary open turn exactly once
- transcript truncation and old/malformed persisted state
- an unexpected disconnected human row preserving the accumulated turn prefix

Verification:

- `uv run pytest tests/unit -v` — 70 passed
- `uv run pytest tests/integration -v` — 9 passed
- `uv run --script hooks/langfuse_hook.py --help` — passed
- `git diff --check` — clean

Addresses the open-turn persistence gap described in #5.
