### PR TITLE
Remove install-required flags from API-key userConfig fields

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -13,14 +13,12 @@
       "type": "string",
       "title": "Langfuse Secret Key",
       "description": "Your Langfuse project secret key (sk-lf-...)",
-      "sensitive": true,
-      "required": true
+      "sensitive": true
     },
     "LANGFUSE_PUBLIC_KEY": {
       "type": "string",
       "title": "Langfuse Public Key",
-      "description": "Your Langfuse project public key (pk-lf-...)",
-      "required": true
+      "description": "Your Langfuse project public key (pk-lf-...)"
     },
     "LANGFUSE_BASE_URL": {
       "type": "string",


### PR DESCRIPTION
Claude Code's interactive `/plugins` install flow chains install directly into the configure form. Fields marked `required: true` have no skip affordance there, so a user who doesn't have their Langfuse keys at hand can only press Esc — which exits with no feedback, leaving the plugin registered but unconfigured and unloaded, indistinguishable from a failed install. Reported upstream as anthropics/claude-code#80904.

The `required` flags buy nothing at runtime: the hook already fail-opens (exits silently, zero impact on Claude Code) until both keys are set, which is exactly the right behavior for an unconfigured install. This PR removes the two flags so menu-flow installs complete cleanly; the keys remain documented as necessary for tracing, and the non-interactive CLI still prints which options are unset after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)