### PR TITLE
feat(hook): drop numbering from LLM call observation names

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1945,14 +1945,13 @@ def build_generation_kwargs(
 def emit_generation_observation(
     langfuse: Langfuse,
     parent_otel_span: Any,
-    generation_prefix: str,
-    assistant_index: int,
+    generation_name: str,
     start_timestamp: Optional[datetime],
     generation_kwargs: Dict[str, Any],
 ) -> Any:
     return _start_backdated(
         langfuse,
-        name=f"{generation_prefix} {assistant_index + 1}",
+        name=generation_name,
         as_type="generation",
         start_time=start_timestamp,
         parent_otel_span=parent_otel_span,
@@ -1961,7 +1960,7 @@ def emit_generation_observation(
 
 def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn,
                            start_timestamp: Optional[datetime],
-                           generation_prefix: str = "LLM Call",
+                           generation_name: str = "LLM Call",
                            subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
                            cursor: Optional[EmissionCursor] = None) -> Optional[datetime]:
     """Emit a turn's generations and tool observations under an existing span.
@@ -2042,8 +2041,7 @@ def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn
             generation_span = emit_generation_observation(
                 langfuse,
                 parent_otel_span=parent_otel_span,
-                generation_prefix=generation_prefix,
-                assistant_index=assistant_index,
+                generation_name=generation_name,
                 start_timestamp=generation_start_timestamp,
                 generation_kwargs=generation_kwargs,
             )
@@ -2148,7 +2146,7 @@ def emit_subagent_observations(langfuse: Langfuse, parent_otel_span: Any,
             subagent_span._otel_span,
             turn,
             previous_start_timestamp,
-            generation_prefix="Subagent LLM Call",
+            generation_name="Subagent LLM Call",
             subagent_transcripts_by_tool_use_id=None,
         )
         latest_end_timestamp = _get_latest_timestamp(latest_end_timestamp, latest_turn_timestamp)

--- a/tests/integration/test_emit_turn_observations.py
+++ b/tests/integration/test_emit_turn_observations.py
@@ -22,10 +22,10 @@ def test_emit_turn_observations_creates_generation_tool_and_subagent_observation
     )
 
     names = [observation.name for observation in fake_langfuse.observations]
-    assert "LLM Call 1" in names
+    assert "LLM Call" in names
     assert "Tool: Agent" in names
     assert "Subagent: Summarize docs" in names
-    assert "Subagent LLM Call 1" in names
+    assert "Subagent LLM Call" in names
     assert "Tool: ToolSearch" in names
     assert latest_end_timestamp.isoformat() == "2026-01-01T00:02:06+00:00"
 

--- a/tests/unit/test_subagent_observations.py
+++ b/tests/unit/test_subagent_observations.py
@@ -30,7 +30,7 @@ def test_subagent_observations_skip_malformed_jsonl_lines(
     assert end_timestamp.isoformat() == "2026-01-01T00:02:04.500000+00:00"
     assert [observation.name for observation in fake_langfuse.observations] == [
         "Subagent: Summarize docs",
-        "Subagent LLM Call 1",
+        "Subagent LLM Call",
         "Tool: ToolSearch",
-        "Subagent LLM Call 2",
+        "Subagent LLM Call",
     ]


### PR DESCRIPTION
## What

Generation observations are no longer numbered per turn, instead they are named by
the bare label instead:

| Before | After |
|---|---|
| `LLM Call 1`, `LLM Call 2`, … | `LLM Call` |
| `Subagent LLM Call 1`, … | `Subagent LLM Call` |

## Changes

- `emit_generation_observation` names generations by the bare label; the
  `assistant_index` parameter is removed (it only existed for the numbering)
- `generation_prefix` renamed to `generation_name` — without the number it is
  the full name, not a prefix
- test expectations updated accordingly

## Notes for review

- No impact on the resume/dedupe logic: emission keys are derived from
  `message.id` (`generation_emission_key`), the observation name is purely
  cosmetic
- Subagent generations lose their numbering too (same naming line) —
  intentional, keeps both consistent
  
  Fixes LFE-14779