### PR TITLE
fix(hook): configurable state directory via CC_LANGFUSE_STATE_DIR

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -57,6 +57,11 @@
       "description": "Include the injected skill instruction text in the Skill tool span output",
       "default": false
     },
+    "CC_LANGFUSE_STATE_DIR": {
+      "type": "string",
+      "title": "State directory",
+      "description": "Optional. Absolute directory for the hook's state, lock and log files (default ~/.claude/state). Set a distinct value per CLAUDE_CONFIG_DIR installation to keep their state separate. Leave empty for the default."
+    },
     "CC_LANGFUSE_TRACE_SEED": {
       "type": "string",
       "title": "Trace ID seed",

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The plugin requires or accepts:
 | `CC_LANGFUSE_MAX_CHARS` | Truncate captured inputs/outputs to this many characters (default 20000).                          |
 | `CC_LANGFUSE_SKILL_TAGS` | Tag traces with `skill:<name>` for every skill invoked in the turn (default true).                 |
 | `CC_LANGFUSE_CAPTURE_SKILL_CONTENT` | Include injected skill instruction text in the Skill tool span output (default false).  |
+| `CC_LANGFUSE_STATE_DIR` | Optional. Absolute directory (`~` is expanded) for the hook's state, lock and log files (default `~/.claude/state`) — set per `CLAUDE_CONFIG_DIR` installation to keep them separate. Unusable values fall back to the default with a logged warning. |
 | `CC_LANGFUSE_TRACE_SEED` | Optional. Opt-in seed for deterministic trace IDs — see [Deterministic trace IDs](#deterministic-trace-ids). |
 | `CC_LANGFUSE_TRACEPARENT` | Optional, per run (env var, not plugin config). W3C traceparent of an existing trace to attach to — see [Attach runs to an existing trace](#attach-runs-to-an-existing-trace). |
 | `CC_LANGFUSE_PARENT_TRACE_ID` / `CC_LANGFUSE_PARENT_SPAN_ID` | Optional, per run. Explicit alternative to `CC_LANGFUSE_TRACEPARENT` (32-hex trace id + 16-hex span id). |
@@ -209,7 +210,7 @@ claude plugin uninstall langfuse-observability
 
 ## Troubleshooting
 
-Nearly every failure explains itself in `~/.claude/state/langfuse_hook.log`. Send one message, then match the newest lines against this table:
+Nearly every failure explains itself in `~/.claude/state/langfuse_hook.log` (with a usable `CC_LANGFUSE_STATE_DIR` override the log lives there instead; a rejected override logs to the default path). Send one message, then match the newest lines against this table:
 
 | What the log shows | Meaning | What to do |
 | --- | --- | --- |

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -26,13 +26,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 
-# ----------------- Paths -----------------
-STATE_DIR = Path.home() / ".claude" / "state"
-LOG_FILE = STATE_DIR / "langfuse_hook.log"
-STATE_FILE = STATE_DIR / "langfuse_state.json"
-LOCK_FILE = STATE_DIR / "langfuse_state.lock"
-
-
 # ----------------- Configuration -----------------
 def _opt(name: str) -> str:
     """Read a plugin userConfig value (CLAUDE_PLUGIN_OPTION_<NAME>) with a fallback to a plain env var."""
@@ -48,6 +41,59 @@ except ValueError:
 
 # Bound for unresolved task notifications kept in the state file between runs.
 MAX_PENDING_TASK_NOTIFICATIONS = 50
+
+
+# ----------------- Paths -----------------
+def _resolve_state_dir() -> Tuple[Path, str]:
+    """Resolve the state directory, taking CC_LANGFUSE_STATE_DIR into account.
+
+    Multi-installation setups (CLAUDE_CONFIG_DIR) point each installation at
+    its own directory so installations stop sharing one log, state file and
+    lock. The historical default is ~/.claude/state, which is used when the 
+    override is unset or invalid. 
+
+    Returns (directory, warning). A non-empty warning means the override was
+    rejected and the default is in use.
+    """
+    default = Path.home() / ".claude" / "state"
+    override = _opt("CC_LANGFUSE_STATE_DIR")
+    if not override:
+        return default, ""
+    try:
+        # expanduser raises RuntimeError for '~unknownuser/...' paths
+        candidate = Path(override).expanduser()
+    except Exception as e:
+        return default, (
+            f"CC_LANGFUSE_STATE_DIR {override!r} is unusable ({type(e).__name__}: {e}); "
+            f"falling back to {default}"
+        )
+    if not candidate.is_absolute():
+        return default, (
+            f"CC_LANGFUSE_STATE_DIR {override!r} is not an absolute path; "
+            f"falling back to {default}"
+        )
+    try:
+        candidate.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        return default, (
+            f"CC_LANGFUSE_STATE_DIR {override!r} is unusable ({type(e).__name__}: {e}); "
+            f"falling back to {default}"
+        )
+    # mkdir(exist_ok=True) passes for a pre-existing dir the user cannot write
+    # to (root-owned, read-only volume); accepting it would kill log, lock and
+    # state at once — the one failure mode with no channel left to report itself.
+    if not os.access(candidate, os.W_OK | os.X_OK):
+        return default, (
+            f"CC_LANGFUSE_STATE_DIR {override!r} is unusable (directory exists but is not writable); "
+            f"falling back to {default}"
+        )
+    return candidate, ""
+
+STATE_DIR, _STATE_DIR_WARNING = _resolve_state_dir()
+LOG_FILE = STATE_DIR / "langfuse_hook.log"
+STATE_FILE = STATE_DIR / "langfuse_state.json"
+LOCK_FILE = STATE_DIR / "langfuse_state.lock"
+
 
 @dataclass
 class LangfuseConfig:
@@ -2631,6 +2677,9 @@ def flush_and_shutdown_langfuse_client(langfuse: Optional[Langfuse]) -> None:
 def main() -> int:
     start = time.time()
     debug("Hook started")
+
+    if _STATE_DIR_WARNING:
+        info(_STATE_DIR_WARNING)
 
     config = get_langfuse_config()
     if config is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import itertools
 import importlib.util
 import json
 import logging
+import os
 import sys
 import types
 from pathlib import Path
@@ -16,6 +17,11 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPO_ROOT / "tests" / "fixtures" / "transcripts"
+
+# A CC_LANGFUSE_STATE_DIR from the developer's real environment would leak into
+# the hook's import-time path resolution; tests that need it set it per test.
+os.environ.pop("CC_LANGFUSE_STATE_DIR", None)
+os.environ.pop("CLAUDE_PLUGIN_OPTION_CC_LANGFUSE_STATE_DIR", None)
 
 
 def _install_langfuse_stubs() -> None:

--- a/tests/unit/test_state_dir.py
+++ b/tests/unit/test_state_dir.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+OPTION = "CC_LANGFUSE_STATE_DIR"
+
+
+@pytest.fixture(autouse=True)
+def clean_state_dir_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OPTION, raising=False)
+    monkeypatch.delenv(f"CLAUDE_PLUGIN_OPTION_{OPTION}", raising=False)
+
+
+def _assert_actionable_fallback(warning: str, rejected_value: str) -> None:
+    # A fallback warning is only useful if it names the option, the rejected
+    # value and where state actually went instead.
+    assert OPTION in warning
+    assert rejected_value in warning
+    assert str(Path.home() / ".claude" / "state") in warning
+
+
+# ----------------- accepted values -----------------
+
+def test_default_without_override(hook_module: Any) -> None:
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == Path.home() / ".claude" / "state"
+    assert warning == ""
+
+
+def test_empty_value_counts_as_unset(hook_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(OPTION, "")
+
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == Path.home() / ".claude" / "state"
+    assert warning == ""
+
+
+def test_plain_env_var_override(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    target = tmp_path / "profile-a" / "state"
+    monkeypatch.setenv(OPTION, str(target))
+
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == target
+    assert warning == ""
+    assert target.is_dir()
+
+
+def test_plugin_option_channel(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    target = tmp_path / "wizard-state"
+    monkeypatch.setenv(f"CLAUDE_PLUGIN_OPTION_{OPTION}", str(target))
+
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == target
+    assert warning == ""
+    assert target.is_dir()
+
+
+def test_tilde_expands_against_home(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(OPTION, "~/agent/state")
+
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == tmp_path / "agent" / "state"
+    assert warning == ""
+
+
+# ----------------- rejected values fall back loudly -----------------
+
+@pytest.mark.parametrize("value", ["relative/state", "./state", " "])
+def test_non_absolute_values_fall_back(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(OPTION, value)
+
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == Path.home() / ".claude" / "state"
+    assert "not an absolute path" in warning
+    _assert_actionable_fallback(warning, value)
+    # The rejected value must not leave a directory behind in the hook's cwd.
+    assert not (Path.cwd() / "relative").exists()
+
+
+def test_unknown_user_tilde_falls_back(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Path.expanduser raises RuntimeError for an unresolvable ~user prefix;
+    # that must degrade to the default, not crash the module import.
+    monkeypatch.setenv(OPTION, "~no-such-user-xyz/state")
+
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == Path.home() / ".claude" / "state"
+    assert "unusable" in warning
+    _assert_actionable_fallback(warning, "~no-such-user-xyz/state")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="permission bits are POSIX semantics")
+def test_existing_unwritable_dir_falls_back(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # mkdir(exist_ok=True) succeeds on an existing read-only dir, so the probe
+    # alone would accept a directory in which log, lock and state all fail.
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root bypasses permission checks")
+    ro = tmp_path / "ro-state"
+    ro.mkdir()
+    ro.chmod(0o555)
+    try:
+        monkeypatch.setenv(OPTION, str(ro))
+
+        state_dir, warning = hook_module._resolve_state_dir()
+
+        assert state_dir == Path.home() / ".claude" / "state"
+        assert "unusable" in warning
+        assert "not writable" in warning
+        _assert_actionable_fallback(warning, str(ro))
+    finally:
+        ro.chmod(0o755)
+
+
+def test_uncreatable_path_falls_back(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    blocker = tmp_path / "blocker"
+    blocker.write_text("a file, not a directory", encoding="utf-8")
+    target = blocker / "state"
+    monkeypatch.setenv(OPTION, str(target))
+
+    state_dir, warning = hook_module._resolve_state_dir()
+
+    assert state_dir == Path.home() / ".claude" / "state"
+    assert "unusable" in warning
+    _assert_actionable_fallback(warning, str(target))
+
+
+# ----------------- import-time wiring -----------------
+
+def _fresh_hook_module(name: str) -> Any:
+    """Import a private module instance so the import-time path resolution
+    (STATE_DIR, _STATE_DIR_WARNING = _resolve_state_dir()) runs under the
+    current test environment. The shared hook_module fixture imports once per
+    session, so it can never observe env vars set inside a test."""
+    module_path = Path(__file__).resolve().parents[2] / "hooks" / "langfuse_hook.py"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+def test_import_wires_globals_to_override(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # hook_module guarantees the langfuse stubs are installed for the fresh import.
+    target = tmp_path / "profile" / "state"
+    monkeypatch.setenv(OPTION, str(target))
+
+    fresh = _fresh_hook_module("langfuse_hook_wiring_override")
+
+    assert fresh.STATE_DIR == target
+    assert fresh._STATE_DIR_WARNING == ""
+    assert fresh.LOG_FILE == target / "langfuse_hook.log"
+    assert fresh.STATE_FILE == target / "langfuse_state.json"
+    assert fresh.LOCK_FILE == target / "langfuse_state.lock"
+
+
+def test_import_wires_fallback_and_warning(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))  # keep the fallback away from the real home
+    monkeypatch.setenv(OPTION, "relative/state")
+
+    fresh = _fresh_hook_module("langfuse_hook_wiring_fallback")
+
+    assert fresh.STATE_DIR == tmp_path / ".claude" / "state"
+    assert "not an absolute path" in fresh._STATE_DIR_WARNING
+
+
+# ----------------- the warning reaches the log -----------------
+
+def test_main_logs_warning_even_without_langfuse_keys(
+    hook_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(hook_module, "_STATE_DIR_WARNING", "CC_LANGFUSE_STATE_DIR test-warning")
+    for name in (
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "CC_LANGFUSE_PUBLIC_KEY",
+        "CC_LANGFUSE_SECRET_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(f"CLAUDE_PLUGIN_OPTION_{name}", raising=False)
+    monkeypatch.setattr("sys.stdin", io.StringIO("{}"))
+
+    assert hook_module.main() == 0
+
+    log = Path(hook_module.LOG_FILE).read_text(encoding="utf-8")
+    assert "CC_LANGFUSE_STATE_DIR test-warning" in log
+    assert "[INFO]" in log


### PR DESCRIPTION
## Summary

`STATE_DIR` was hardcoded to `~/.claude/state` at import time, so multi-installation setups (`CLAUDE_CONFIG_DIR`) shared one log, one state file and one lock across installations (langfuse/claude-observability-plugin#41): unattributable log lines, state landing in a directory the operator deliberately stopped using, and needless cross-installation lock contention (a 2s lock timeout silently skips a firing).

This PR adds an opt-in `CC_LANGFUSE_STATE_DIR` option, settable as a plain env var (e.g. from the same launcher that sets `CLAUDE_CONFIG_DIR`) or via the plugin config wizard. It points the hook's state, lock and log at a per-installation directory; the three files always travel together.

**Unset behavior is byte-identical to today** — no migration, no offset reset, no re-ingest risk.

## Design decisions

* **Opt-in option instead of deriving from** `CLAUDE_CONFIG_DIR` (the issue's preferred fix): automatic derivation would move `STATE_FILE` on upgrade for existing multi-installation users —> byte offsets restart at 0 and already-traced history is re-emitted.
* **Fail open, loudly**: unusable values (relative paths, unresolvable `~user`, uncreatable or existing-but-unwritable directories) fall back to the default and log an INFO-level warning on every firing — a misconfigured override can never silently disable tracing or the hook's own log.
* The option is declared in `plugin.json` `userConfig`, so the wizard channel works; wizard values are stored per `CLAUDE_CONFIG_DIR` installation, which is exactly the scope this option targets.

## Testing

* 14 new unit tests: value handling and precedence channels, `~` expansion, all fallback branches with actionable warning texts, import-time wiring of the four path globals, and the `main()` warning path (suite: 137 passed).
* E2E sandbox: two simulated installations write fully separated `state/` directories with the option set; without it the default location and behavior are unchanged; a broken override falls back with a visible warning.
* `tests/conftest.py` scrubs the option from the ambient environment so a developer/CI machine using the override cannot break test isolation.

## Notes for review

* Follow-up issue for phase 2 (automatic `CLAUDE_CONFIG_DIR` derivation + legacy bookmark migration) to be filed after this merges.

Closes langfuse/claude-observability-plugin#41<br>Fixes langfuse/claude-observability-plugin#41