### PR TITLE
fix(hook): let per-repo env vars win over machine-wide wizard config

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -35,8 +35,12 @@ LOCK_FILE = STATE_DIR / "langfuse_state.lock"
 
 # ----------------- Configuration -----------------
 def _opt(name: str) -> str:
-    """Read a plugin userConfig value (CLAUDE_PLUGIN_OPTION_<NAME>) with a fallback to a plain env var."""
-    return os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name}") or os.environ.get(name) or ""
+    """Read a config value: plain env var first, plugin userConfig (CLAUDE_PLUGIN_OPTION_<NAME>) as fallback.
+
+    Claude Code stores plugin userConfig at machine scope only, while `env` blocks
+    are per-repo — so the repo-level env var must win, wizard as fallback.
+    """
+    return os.environ.get(name) or os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name}") or ""
 
 DEBUG = _opt("CC_LANGFUSE_DEBUG").lower() == "true"
 SKILL_TAGS = (_opt("CC_LANGFUSE_SKILL_TAGS") or "true").lower() == "true"
@@ -115,11 +119,26 @@ def get_parent_trace_context_from_env() -> Tuple[Optional[str], Optional[str]]:
         return None, None
     return parent_trace_id, parent_span_id
 
+def _core_opt(name: str) -> Tuple[str, str]:
+    """Resolve NAME/CC_NAME source-first — any env spelling beats any wizard
+    spelling — returning (value, source) for mixed-source detection."""
+    for source, key in (
+        ("env", name),
+        ("env", f"CC_{name}"),
+        ("wizard", f"CLAUDE_PLUGIN_OPTION_{name}"),
+        ("wizard", f"CLAUDE_PLUGIN_OPTION_CC_{name}"),
+    ):
+        value = os.environ.get(key)
+        if value:
+            return value, source
+    return "", ""
+
 def get_langfuse_config() -> Optional[LangfuseConfig]:
-    public_key = _opt("LANGFUSE_PUBLIC_KEY") or _opt("CC_LANGFUSE_PUBLIC_KEY")
-    secret_key = _opt("LANGFUSE_SECRET_KEY") or _opt("CC_LANGFUSE_SECRET_KEY")
-    host = _opt("LANGFUSE_BASE_URL") or _opt("CC_LANGFUSE_BASE_URL") or "https://us.cloud.langfuse.com"
-    user_id = _opt("LANGFUSE_USER_ID") or _opt("CC_LANGFUSE_USER_ID") or None
+    public_key, public_key_source = _core_opt("LANGFUSE_PUBLIC_KEY")
+    secret_key, secret_key_source = _core_opt("LANGFUSE_SECRET_KEY")
+    host, host_source = _core_opt("LANGFUSE_BASE_URL")
+    host = host or "https://us.cloud.langfuse.com"
+    user_id = _core_opt("LANGFUSE_USER_ID")[0] or None
     trace_seed = _opt("CC_LANGFUSE_TRACE_SEED") or None
     parent_trace_id, parent_span_id = get_parent_trace_context_from_env()
     if parent_trace_id is not None and trace_seed is not None:
@@ -130,6 +149,17 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
 
     if not public_key or not secret_key:
         return None
+
+    # Export auth failures are swallowed downstream (capped background flush),
+    # so this is the only place a torn key/host pair is still diagnosable.
+    sources = {s for s in (public_key_source, secret_key_source, host_source) if s}
+    if len(sources) > 1:
+        info(
+            "Langfuse config is mixed-source: public_key from "
+            f"{public_key_source}, secret_key from {secret_key_source}, "
+            f"base_url from {host_source or 'default'} — mismatched key/host "
+            "pairs fail with 401 and traces are dropped."
+        )
 
     return LangfuseConfig(
         public_key=public_key,
@@ -143,9 +173,9 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
 
 def _missing_langfuse_keys() -> List[str]:
     missing = []
-    if not (_opt("LANGFUSE_PUBLIC_KEY") or _opt("CC_LANGFUSE_PUBLIC_KEY")):
+    if not _core_opt("LANGFUSE_PUBLIC_KEY")[0]:
         missing.append("LANGFUSE_PUBLIC_KEY")
-    if not (_opt("LANGFUSE_SECRET_KEY") or _opt("CC_LANGFUSE_SECRET_KEY")):
+    if not _core_opt("LANGFUSE_SECRET_KEY")[0]:
         missing.append("LANGFUSE_SECRET_KEY")
     return missing
 

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -137,7 +137,7 @@ def get_langfuse_config() -> Optional[LangfuseConfig]:
     public_key, public_key_source = _core_opt("LANGFUSE_PUBLIC_KEY")
     secret_key, secret_key_source = _core_opt("LANGFUSE_SECRET_KEY")
     host, host_source = _core_opt("LANGFUSE_BASE_URL")
-    host = host or "https://us.cloud.langfuse.com"
+    host = host or "https://cloud.langfuse.com"
     user_id = _core_opt("LANGFUSE_USER_ID")[0] or None
     trace_seed = _opt("CC_LANGFUSE_TRACE_SEED") or None
     parent_trace_id, parent_span_id = get_parent_trace_context_from_env()

--- a/tests/unit/test_config_precedence.py
+++ b/tests/unit/test_config_precedence.py
@@ -1,0 +1,186 @@
+"""Pins the config precedence: plain env vars beat machine-wide wizard values,
+and they beat them as a source tier — a wizard value under one spelling must
+not shadow a repo env var under the other (LANGFUSE_X vs CC_LANGFUSE_X)."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+CORE_NAMES = [
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_BASE_URL",
+    "LANGFUSE_USER_ID",
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in CORE_NAMES:
+        for key in (
+            name,
+            f"CC_{name}",
+            f"CLAUDE_PLUGIN_OPTION_{name}",
+            f"CLAUDE_PLUGIN_OPTION_CC_{name}",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _read_log(hook_module: Any) -> str:
+    log = Path(hook_module.LOG_FILE)
+    return log.read_text(encoding="utf-8") if log.exists() else ""
+
+
+# ----------------- _opt: plain env var wins over wizard -----------------
+
+def test_plain_env_var_wins_over_wizard_option(hook_module: Any, monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-repo")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == "pk-lf-repo"
+
+
+def test_wizard_option_is_the_fallback_when_no_env_var_is_set(hook_module: Any, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == "pk-lf-machine"
+
+
+def test_empty_env_var_falls_through_to_wizard_option(hook_module: Any, monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == "pk-lf-machine"
+
+
+def test_neither_set_yields_empty_string(hook_module: Any, monkeypatch):
+    assert hook_module._opt("LANGFUSE_PUBLIC_KEY") == ""
+
+
+# ----------------- source tier beats spelling -----------------
+
+def test_repo_cc_alias_beats_wizard_value(hook_module: Any, monkeypatch):
+    # The wizard materializes the plain names on every wizard install; a repo
+    # routing via the namespaced spelling must still win.
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_SECRET_KEY", "sk-machine")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_USER_ID", "user-machine")
+    monkeypatch.setenv("CC_LANGFUSE_PUBLIC_KEY", "pk-lf-repo")
+    monkeypatch.setenv("CC_LANGFUSE_SECRET_KEY", "sk-repo")
+    monkeypatch.setenv("LANGFUSE_USER_ID", "user-repo")
+
+    config = hook_module.get_langfuse_config()
+
+    assert config is not None
+    assert config.public_key == "pk-lf-repo"
+    assert config.secret_key == "sk-repo"
+    assert config.user_id == "user-repo"
+
+
+def test_empty_env_vars_fall_through_to_wizard_for_core_opt(hook_module: Any, monkeypatch):
+    # A cleared placeholder ("") must count as unset on both env rungs, or an
+    # empty repo value would silently disable a valid wizard config.
+    name = "LANGFUSE_PUBLIC_KEY"
+    monkeypatch.setenv(name, "")
+    monkeypatch.setenv(f"CC_{name}", "")
+    monkeypatch.setenv(f"CLAUDE_PLUGIN_OPTION_{name}", "wizard-plain")
+
+    assert hook_module._core_opt(name) == ("wizard-plain", "wizard")
+
+
+def test_core_opt_returns_empty_pair_when_nothing_is_set(hook_module: Any):
+    assert hook_module._core_opt("LANGFUSE_PUBLIC_KEY") == ("", "")
+
+
+def test_core_opt_resolves_the_full_ladder(hook_module: Any, monkeypatch):
+    name = "LANGFUSE_PUBLIC_KEY"
+    monkeypatch.setenv(f"CLAUDE_PLUGIN_OPTION_CC_{name}", "wizard-cc")
+    assert hook_module._core_opt(name) == ("wizard-cc", "wizard")
+
+    monkeypatch.setenv(f"CLAUDE_PLUGIN_OPTION_{name}", "wizard-plain")
+    assert hook_module._core_opt(name) == ("wizard-plain", "wizard")
+
+    monkeypatch.setenv(f"CC_{name}", "env-cc")
+    assert hook_module._core_opt(name) == ("env-cc", "env")
+
+    monkeypatch.setenv(name, "env-plain")
+    assert hook_module._core_opt(name) == ("env-plain", "env")
+
+
+# ----------------- mixed-source configs warn -----------------
+
+def test_partial_repo_env_block_warns_mixed_source(hook_module: Any, monkeypatch):
+    # Keys from the repo, base URL left to the wizard's machine-wide value:
+    # the classic partial env block that 401s against the wrong host.
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-repo")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-repo")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
+
+    config = hook_module.get_langfuse_config()
+
+    assert config is not None
+    assert config.host == "https://cloud.langfuse.com"
+    log = _read_log(hook_module)
+    assert "mixed-source" in log
+    assert "base_url from wizard" in log
+
+
+def test_torn_key_pair_warns_mixed_source(hook_module: Any, monkeypatch):
+    # The most dangerous mix: the two keys themselves from different sources.
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-repo")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_SECRET_KEY", "sk-machine")
+
+    config = hook_module.get_langfuse_config()
+
+    assert config is not None
+    log = _read_log(hook_module)
+    assert "mixed-source" in log
+    assert "secret_key from wizard" in log
+    assert "base_url from default" in log
+
+
+def test_wizard_keys_with_env_host_warn_mixed_source(hook_module: Any, monkeypatch):
+    # The reverse direction: keys from the wizard, host from the environment.
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_SECRET_KEY", "sk-machine")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "https://langfuse.example.com")
+
+    config = hook_module.get_langfuse_config()
+
+    assert config is not None
+    assert config.host == "https://langfuse.example.com"
+    assert "mixed-source" in _read_log(hook_module)
+
+
+def test_wizard_only_config_does_not_warn(hook_module: Any, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_PUBLIC_KEY", "pk-lf-machine")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_SECRET_KEY", "sk-machine")
+    monkeypatch.setenv("CLAUDE_PLUGIN_OPTION_LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
+
+    assert hook_module.get_langfuse_config() is not None
+    assert "mixed-source" not in _read_log(hook_module)
+
+
+def test_single_source_config_does_not_warn(hook_module: Any, monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-repo")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-repo")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "https://langfuse.example.com")
+
+    assert hook_module.get_langfuse_config() is not None
+    assert "mixed-source" not in _read_log(hook_module)
+
+
+def test_env_keys_with_code_default_host_do_not_warn(hook_module: Any, monkeypatch):
+    # No wizard value anywhere: falling back to the built-in default is not
+    # a mixed config, it is the documented single-source setup.
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-repo")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-repo")
+
+    config = hook_module.get_langfuse_config()
+
+    assert config is not None
+    assert config.host == "https://us.cloud.langfuse.com"
+    assert config.user_id is None
+    assert "mixed-source" not in _read_log(hook_module)


### PR DESCRIPTION
## Summary

Claude Code stores plugin `userConfig` at user (machine) scope only, while a project's `env` block in `.claude/settings.local.json` is per-repo.

Before, the hook read the wizard value first, so one saved wizard config silently rerouted **every** project on the machine to a single Langfuse project, therefore per-repo routing (per-client billing, retention, data isolation) was impossible, with no error and no visible sign (langfuse/claude-observability-plugin#30).

This PR fixes the precedence at both levels:

* `_opt()` **reads the plain env var first**, wizard as fallback (the flip proposed in [#31](<https://github.com/langfuse/claude-observability-plugin/issues/31>)).
* **The four core values resolve source-first across both spellings** via a new `_core_opt()`: `env LANGFUSE_X` → `env CC_LANGFUSE_X` → `wizard LANGFUSE_X` → `wizard CC_LANGFUSE_X`. The flip alone is not enough: `_opt(NAME) or _opt(CC_NAME)` groups by name, so the wizard's always-materialized `LANGFUSE_X` (the wizard marks the key fields required) still shadowed a repo's `CC_LANGFUSE_X` env var — the same silent rerouting, surviving on the plugin's namespaced spelling.
* **Mixed-source configs now log one redacted INFO line** (sources only, no values). After the flip, a partial repo env block splices with wizard leftovers (e.g. repo keys + wizard base URL); mismatched pairs fail with 401 while the export error is swallowed, so this is the only place the combination is still diagnosable.

Wizard-only setups are unaffected: with no repo-level env vars set, the wizard value applies exactly as before.

## Testing

* 14 unit tests pinning every branch: both `_opt` orders, the full four-rung ladder, empty-string fall-through on all env rungs, `user_id` resolution, and the mixed-source warning in both directions plus its non-firing cases. The suite is mutation-hardened — reverting the flip, re-grouping by name, or narrowing the warning each fails at least one test. Full suite: 137 passed.
* Sandbox A/B against auth-recording sinks (pre/post-flip): repo `LANGFUSE_*` env wins, repo `CC_LANGFUSE_*` env wins, torn key/host pairs produce the warning.
* End-to-end against Langfuse Cloud with two projects and two repos: without the fix both repos traced into the wizard's project; with it, the repo with its own env block routes to its own project (verified for both spellings), and the repo without one stays on the wizard fallback.

Closes langfuse/claude-observability-plugin#30  <br>Fixes langfuse/claude-observability-plugin#30