### PR TITLE
fix(hook): stop silent export skips from state-lock contention

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -311,7 +311,14 @@ def is_session_end_hook_payload(payload: Dict[str, Any]) -> bool:
 
 # ----------------- State file concurrency control -----------------
 class FileLock:
-    def __init__(self, path: Path, timeout_s: float = 2.0):
+    # The lock is held for the whole of emit_new_turns_from_transcript, which
+    # includes emitting to Langfuse over the network, so hold time scales with
+    # how much a session has to flush (an 82-turn flush was measured at 2.16s).
+    # The timeout therefore has to exceed a full flush, not just a state-file
+    # write. Waiting is strictly better than the alternative here: the hook is
+    # async and the work is idempotent, so a slow acquire costs latency while a
+    # failed acquire costs data.
+    def __init__(self, path: Path, timeout_s: float = 30.0):
         self.path = path
         self.timeout_s = timeout_s
         self._fh = None
@@ -2661,7 +2668,11 @@ def main() -> int:
         return 0
 
     except TimeoutError as e:
-        debug(f"lock timeout, skipping: {e}")
+        # Skipping means this turn is not exported until the session's next
+        # Stop, and never at all if the session goes idle first. Log at info so
+        # it is visible without CC_LANGFUSE_DEBUG, since the symptom shows up in
+        # Langfuse as missing data with no client-side trace of the cause.
+        info(f"lock timeout, skipping: {e}")
         return 0
 
     except Exception as e:


### PR DESCRIPTION
Fixes the two immediate items from #48 (items 3 and 4 in that issue's list).

## Problem

`emit_new_turns_from_transcript()` holds one global `flock` for its entire duration — reading the transcript, parsing turns, **emitting to Langfuse over the network**, and saving state. Hold time therefore scales with how much a session has to flush, and a real 82-turn flush from my own log took **2.16s**:

```
2026-08-08 00:09:38 [INFO] Processed 82 turns in 2.16s (session=4d012f34-...)
```

That already exceeds the 2.0s acquisition timeout, so any concurrent session reaching `Stop` during a large flush loses the race. On timeout, `main()` caught the `TimeoutError`, logged it at `debug`, and returned `0` — reporting success. Since `CC_LANGFUSE_DEBUG` defaults to `false`, this left **no trace at all**: the turn isn't exported until that session's next `Stop`, and never if the session goes idle first. The symptom is Langfuse collecting only one of several concurrent sessions, with the apparent fault server-side and the actual cause entirely client-side.

## Changes

- **Lock timeout 2.0s → 30.0s.** Waiting is strictly better than skipping here: the hook is async and the work is idempotent, so a slow acquire costs latency while a failed acquire costs data.
- **Skip logged at `info` instead of `debug`**, so the cause is visible without opting into debug logging.

## What this does not fix

This mitigates the contention; it doesn't remove it. The root problem is that the lock spans network I/O, so hold time stays unbounded and data-dependent — a large enough backfill could still exhaust any fixed timeout. The structural fixes suggested in #48 still stand:

- Narrow the critical section so the lock isn't held across the emit, or
- Move to per-session state files, which removes the contention outright since `state` is already keyed by `get_session_state_key(session_id, transcript_path)` and concurrent sessions share nothing that needs mutual exclusion.

Happy to follow up with either if you have a preference on direction.

## Testing

`uv run -m pytest` → **123 passed**. No existing test references `FileLock` or `timeout_s`, so nothing needed updating; I didn't add a test for the new default since asserting on a timing constant would mostly pin the number rather than the behaviour, but glad to add one if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
