### PR TITLE
fix(plugin): align test pin, wizard default and docs with the EU code default

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,7 +26,7 @@
       "type": "string",
       "title": "Langfuse Base URL",
       "description": "Langfuse host. Use https://us.cloud.langfuse.com for US, https://cloud.langfuse.com for EU, or your self-hosted URL.",
-      "default": "https://us.cloud.langfuse.com"
+      "default": "https://cloud.langfuse.com"
     },
     "LANGFUSE_USER_ID": {
       "type": "string",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The plugin requires or accepts:
 | --------------------- | ---------------------------------------------------------------------------------------------------- |
 | `LANGFUSE_SECRET_KEY` | Your Langfuse secret key (`sk-lf-...`). Stored in your OS keychain.                                  |
 | `LANGFUSE_PUBLIC_KEY` | Your Langfuse public key (`pk-lf-...`).                                                              |
-| `LANGFUSE_BASE_URL`   | https://us.cloud.langfuse.com (default), https://cloud.langfuse.com for EU, or your self-hosted URL. |
+| `LANGFUSE_BASE_URL`   | https://cloud.langfuse.com (default, EU), https://us.cloud.langfuse.com for US, or your self-hosted URL. |
 | `LANGFUSE_USER_ID`    | Optional. User identifier attached to every trace (shown as the user in Langfuse).                   |
 | `CC_LANGFUSE_DEBUG`   | Verbose logging to `~/.claude/state/langfuse_hook.log`.                                              |
 | `CC_LANGFUSE_MAX_CHARS` | Truncate captured inputs/outputs to this many characters (default 20000).                          |
@@ -165,8 +165,7 @@ Instead of `CC_LANGFUSE_TRACEPARENT` you can pass `CC_LANGFUSE_PARENT_TRACE_ID` 
 
 This plugin transmits your Claude Code session data — conversation turns, assistant
 generations, tool calls, and token-usage statistics — to the Langfuse endpoint you
-configure (`LANGFUSE_BASE_URL`, default `https://us.cloud.langfuse.com`; EU and
-self-hosted endpoints are supported). Data is sent at the end of each turn (the
+configure (`LANGFUSE_BASE_URL`, default `https://cloud.langfuse.com`). Data is sent at the end of each turn (the
 `Stop` hook) and at session end (`SessionEnd`) using the Langfuse API keys you
 provide, which are stored in your OS keychain. No data is sent anywhere other than
 the endpoint you configure.

--- a/tests/unit/test_config_precedence.py
+++ b/tests/unit/test_config_precedence.py
@@ -181,6 +181,6 @@ def test_env_keys_with_code_default_host_do_not_warn(hook_module: Any, monkeypat
     config = hook_module.get_langfuse_config()
 
     assert config is not None
-    assert config.host == "https://us.cloud.langfuse.com"
+    assert config.host == "https://cloud.langfuse.com"
     assert config.user_id is None
     assert "mixed-source" not in _read_log(hook_module)


### PR DESCRIPTION
This PR changes the code-default host to https://cloud.langfuse.com (EU).

Before Merge: US is default

1. The test pinning the code default still expected `us.cloud`
2. The wizard default (`plugin.json`) and README still advertised `us.cloud`, contradicting the code.

Commit 1 updates the test pin (unbreaks `main`); commit 2 aligns the wizard default and README. If the EU default was meant for the code only, happy to drop commit 2.

Fixes LFE-14926