### PR TITLE
fix(plugin): drop the static version so plugin updates track main

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "langfuse-observability",
   "description": "The Langfuse x Claude Code Observability Plugin",
-  "version": "1.0.0",
   "author": {
     "name": "Langfuse"
   },

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ The plugin requires or accepts:
 
 Get keys from your Langfuse project settings → API Keys.
 
+## Update
+
+```bash
+claude plugin marketplace update langfuse-observability
+claude plugin update langfuse-observability@langfuse-observability
+```
+
+The first command gets the latest plugin code from GitHub. The second command installs the plugin. Then restart Claude Code.
+
 ## Requirements
 
 One of:

--- a/tests/unit/test_plugin_manifest.py
+++ b/tests/unit/test_plugin_manifest.py
@@ -1,0 +1,34 @@
+"""Distribution rules for the plugin manifests.
+
+Claude Code reads the plugin version from the `version` field. If the
+manifests have no `version` field, Claude Code uses the git commit, and each
+new commit becomes an update. The manifests must not have a `version` field.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name: str) -> Any:
+    return json.loads((REPO_ROOT / ".claude-plugin" / name).read_text(encoding="utf-8"))
+
+
+def test_plugin_manifest_declares_no_static_version() -> None:
+    manifest = _load("plugin.json")
+
+    assert manifest["name"] == "langfuse-observability"
+    assert "version" not in manifest
+
+
+def test_marketplace_entries_declare_no_static_version() -> None:
+    marketplace = _load("marketplace.json")
+
+    entries = marketplace["plugins"]
+    assert entries, "marketplace.json must list the plugin"
+    for entry in entries:
+        assert "version" not in entry


### PR DESCRIPTION
## Problem

`claude plugin update` reports "already at the latest version (1.0.0)". But `main` is many commits ahead. Installs stay on the commit they got at install time as the version field is never updated and proper versioning of the integration not set up yet. #51 shows a full reproduction.

## Cause

Claude Code reads the update version from the `version` field in `plugin.json`. It compares this string to the installed version and thereby it does not compare git commits ([docs: Version management](https://code.claude.com/docs/en/plugins-reference#version-management)).

If we keep our version field as is at `1.0.0` (since the first commit), the CLI never offers an update. The pinned version also blocks updates from the official Anthropic plugin directory as even if the directory re-pins commits, the manifest version has priority.

## Fix

We remove the `version` field. Claude Code then uses the git commit as the version. Each commit on `main` becomes an update. This matches how we ship the plugin today: new installs always get the newest commit.

- `.claude-plugin/plugin.json` — remove the field
- `README.md` — add an "Update" section with the two update commands
- `tests/unit/test_plugin_manifest.py` — new test: the manifests must not declare a `version` field again (`claude plugin validate` suggests one, so this can easily happen)

This PR adds no release process. If we want semver releases later, we add the field back, together with release tags (`claude plugin tag-release`). 

## Verification

We tested against the real CLI (v2.1.224) in an isolated `CLAUDE_CONFIG_DIR`, with a local marketplace that mirrors this repo (`source: "./"`).

- With the pinned version: the marketplace pulls new commits, but the installed files stay old. This is the bug.
- Without the field: the CLI reports `updated from 1.0.0 to <commit-id>`. Stale installs move to the new model on their next update. No reinstall is needed.
- The test suite passes (170 tests). `claude plugin validate .` passes.

After the merge, users on a stale install run:

```
claude plugin marketplace update langfuse-observability
claude plugin update langfuse-observability@langfuse-observability
```

Fixes #51
Linear: LFE-14887