### PR TITLE
feat(hook): configurable trace name style for name-based grouping

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1696,18 +1696,8 @@ def collect_subagent_skill_tags(
                 add_skill_tags_from_rows(rows, names, "subagent-skill:")
     return names
 
-def short_session_label(session_id: str, max_len: int = 12) -> str:
-    """Return a compact session label for trace names."""
-    sid = session_id.strip()
-    if not sid:
-        return "unknown"
-    parts = sid.split("-")
-    if len(parts) == 5 and len(parts[0]) == 8:
-        return parts[0]
-    return sid if len(sid) <= max_len else sid[:max_len].rstrip("-")
-
-def trace_display_name(session_id: str, turn_num: int) -> str:
-    return f"Claude Code - Turn {turn_num} ({short_session_label(session_id)})"
+# Constant on purpose: a shared trace name keeps Langfuse name-based grouping usable.
+TRACE_NAME = "Claude Code Turn"
 
 def get_trace_tags(
     turn: Turn,
@@ -2679,7 +2669,7 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
         attribute_propagation = propagate_attributes(
             session_id=session_id,
             user_id=user_id,
-            trace_name=trace_display_name(session_id, turn_num),
+            trace_name=TRACE_NAME,
             tags=get_trace_tags(turn, subagent_transcripts_by_tool_use_id),
         )
     else:

--- a/tests/integration/test_parent_trace_attachment.py
+++ b/tests/integration/test_parent_trace_attachment.py
@@ -146,7 +146,8 @@ def test_attached_mode_does_not_propagate_trace_level_attributes(
         fake_langfuse, standalone, "session-standalone", write_two_turn_transcript(standalone_dir)
     )
     assert calls
-    assert all("trace_name" in call for call in calls)
+    assert all(call.get("trace_name") == "Claude Code Turn" for call in calls)
+    assert all(call.get("session_id") == "session-standalone" for call in calls)
 
 
 def test_attached_open_turn_resumes_without_reopening_its_root(


### PR DESCRIPTION
## What

This PR adds the option `CC_LANGFUSE_TRACE_NAME_STYLE`. The option selects one of two styles for the trace name:

<!-- linear:table-colwidths:400,400 -->
| Style | Trace name |
| -- | -- |
| `detailed` (default) | `Claude Code - Turn 3 (abc12345)` — the current behavior |
| `static` | `Claude Code Turn` for each trace |

The detailed name contains the turn number and a session label. The turn number increases within each session. The session label is different for each session. As a result, each trace gets a unique name.

At the same time Langfuse uses the trace name as a group dimension. Unique names make this dimension unusable:

* Dashboard widgets that group traces by name show one trace for each group.
* Metrics that group by trace name divide into groups of one trace.
* Evaluators cannot select Claude Code traces by name.

The `static` style gives the same name to all traces. Then groups by name operate correctly. The trace keeps the session id and the metadata field `turn_number`. The Sessions view and the metadata filters do not change.

## Changes

* The new function `_resolve_trace_name_style()` reads the option and validates the value. It reads the plugin userConfig channel and the plain environment variable. If the value is not valid, the hook uses `detailed` and writes a warning to the log at start. This is the same fail-open pattern as `CC_LANGFUSE_STATE_DIR`.
* The function `trace_display_name()` returns the constant name when the style is `static`.
* The file `plugin.json` shows the option in the configuration wizard.
* The README documents the option.
* New unit tests check the resolver and the two name styles.

## Notes for review

* The default stays `detailed`. PR [#9](<https://github.com/langfuse/claude-observability-plugin/issues/9>) added the session label intentionally, because traces from different sessions looked like duplicates. The reporter of issue langfuse/claude-observability-plugin#50 asked to keep the current default.
* Attached mode is not affected. In attached mode, the hook does not propagate a trace name.
* An alternative is a constant name without an option. The Codex plugin uses the constant name `Codex Turn`. Tell me if you prefer this alternative — the change is small.
* I did an end-to-end test against Langfuse Cloud through the wizard environment channel (`CLAUDE_PLUGIN_OPTION_CC_LANGFUSE_TRACE_NAME_STYLE=static`).

Fixes langfuse/claude-observability-plugin#50  <br>Fixes langfuse/claude-observability-plugin#50