### PR TITLE
feat: attach project name to trace metadata

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -2585,6 +2585,8 @@ def build_trace_metadata(
         value = turn.user_msg.get(src_key)
         if isinstance(value, str) and value:
             trace_metadata[dst_key] = value
+            if src_key == "cwd":
+                trace_metadata["project"] = Path(value).name
     return trace_metadata
 
 def is_valid_span_id_hex(span_id: Any) -> bool:

--- a/tests/unit/test_langfuse_payload_builders.py
+++ b/tests/unit/test_langfuse_payload_builders.py
@@ -111,6 +111,7 @@ def test_trace_metadata_includes_session_turn_project_and_branch(
     assert metadata["session_id"] == "12345678-abcd-4000-8000-123456789abc"
     assert metadata["turn_number"] == 7
     assert metadata["transcript_path"] == "transcript.jsonl"
+    assert metadata["project"] == "repo"
     assert metadata["cwd"] == "/repo"
     assert metadata["git_branch"] == "feature/test"
 


### PR DESCRIPTION
Adds a short project field derived from the existing cwd metadata. This lets Langfuse traces be grouped by checkout while retaining the full cwd and Git branch context. Verification: 183 tests pass.