### PR TITLE
perf(hook): read workflow run directories only when a turn references them

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1437,48 +1437,76 @@ def get_workflow_journal_results(run_dir: Path) -> Dict[str, Any]:
             results_by_agent_id[agent_id] = journal_row.get("result")
     return results_by_agent_id
 
-def get_workflow_agent_transcripts_by_run_id(transcript_path: Path) -> Dict[str, List[Dict[str, Any]]]:
-    """Map Workflow run ids to the workflow-spawned agent transcripts on disk.
+def get_workflow_agents_in_run_dir(run_dir: Path) -> List[Dict[str, Any]]:
+    """The workflow-spawned agent transcripts of one Workflow run directory.
 
-    Workflow-tool agents live under <stem>/subagents/workflows/wf_<runId>/;
+    Workflow-tool agents live under <stem>/subagents/workflows/<runId>/;
     their meta.json carries agentType=="workflow-subagent" and — unlike
-    classic subagents — no toolUseId, so they are keyed by the run id (the
-    directory name) instead. The launching tool_use is linked via
-    toolUseResult.runId on the parent transcript's tool_result row
-    (see get_workflow_launch_marker_from_row).
+    classic subagents — no toolUseId, so a run is identified by its directory
+    name instead. The launching tool_use is linked via toolUseResult.runId on
+    the parent transcript's tool_result row (see
+    get_workflow_launch_marker_from_row).
     """
-    workflows_dir = transcript_path.with_suffix("") / "subagents" / "workflows"
-    if not workflows_dir.is_dir():
-        return {}
+    if not run_dir.is_dir():
+        return []
 
-    workflow_agents_by_run_id: Dict[str, List[Dict[str, Any]]] = {}
-    for run_dir in sorted(workflows_dir.glob("wf_*")):
-        if not run_dir.is_dir():
+    journal_results = get_workflow_journal_results(run_dir)
+    agents: List[Dict[str, Any]] = []
+    for meta_path in sorted(run_dir.glob("agent-*.meta.json")):
+        try:
+            metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
             continue
-        journal_results = get_workflow_journal_results(run_dir)
-        agents: List[Dict[str, Any]] = []
-        for meta_path in sorted(run_dir.glob("agent-*.meta.json")):
+        if not isinstance(metadata, dict) or metadata.get("agentType") != "workflow-subagent":
+            continue
+
+        resolved = resolve_agent_jsonl_and_id(meta_path)
+        if resolved is None:
+            continue
+        jsonl_path, agent_id = resolved
+
+        agents.append({
+            "path": jsonl_path,
+            "agent_id": agent_id,
+            "agent_type": metadata.get("agentType"),
+            "result": journal_results.get(agent_id),
+        })
+    return agents
+
+
+class WorkflowAgentTranscriptsByRunId:
+    """Per-run lookup of workflow-spawned agent transcripts. It reads on demand.
+
+    The first lookup of a run id reads that run directory. The lookup then keeps
+    the result for its own life, which is one hook firing. Thus only a firing
+    that emits a reference to a run reads that run, and it always reads the
+    current files."""
+
+    def __init__(self, transcript_path: Path) -> None:
+        self._workflows_dir = transcript_path.with_suffix("") / "subagents" / "workflows"
+        self._agents_by_run_id: Dict[str, List[Dict[str, Any]]] = {}
+
+    def get(self, run_id: Optional[str]) -> Optional[List[Dict[str, Any]]]:
+        if not isinstance(run_id, str) or not run_id:
+            return None
+        # A run id comes from transcript data, and this method makes a path from
+        # it. Thus the method must accept only a single plain directory name.
+        # The name test rejects each other shape, but not "..", whose Path.name
+        # is ".." again.
+        if run_id == ".." or run_id != Path(run_id).name:
+            return None
+        if run_id not in self._agents_by_run_id:
             try:
-                metadata = json.loads(meta_path.read_text(encoding="utf-8"))
-            except Exception:
-                continue
-            if not isinstance(metadata, dict) or metadata.get("agentType") != "workflow-subagent":
-                continue
-
-            resolved = resolve_agent_jsonl_and_id(meta_path)
-            if resolved is None:
-                continue
-            jsonl_path, agent_id = resolved
-
-            agents.append({
-                "path": jsonl_path,
-                "agent_id": agent_id,
-                "agent_type": metadata.get("agentType"),
-                "result": journal_results.get(agent_id),
-            })
-        if agents:
-            workflow_agents_by_run_id[run_dir.name] = agents
-    return workflow_agents_by_run_id
+                agents = get_workflow_agents_in_run_dir(self._workflows_dir / run_id)
+            except OSError as e:
+                # The file system can refuse a run path, for example when the
+                # name is too long. Such a failure must not stop the turn.
+                debug(f"Workflow run {run_id} not readable: {e}")
+                agents = []
+            if agents:
+                debug(f"Discovered {len(agents)} workflow agent transcript(s) for run {run_id}")
+            self._agents_by_run_id[run_id] = agents
+        return self._agents_by_run_id[run_id] or None
 
 def get_task_id_to_tool_use_id(
     subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]],
@@ -1877,7 +1905,7 @@ def emit_single_tool_observation(
     pending_async_tool_results: List[Dict[str, Any]],
     cursor: EmissionCursor,
     tool_key: str,
-    workflow_agent_transcripts_by_run_id: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    workflow_agent_transcripts_by_run_id: Optional[WorkflowAgentTranscriptsByRunId] = None,
 ) -> EmittedSingleToolObservation:
     tool_use_id = str(tool_use.get("id") or "")
     tool_name = tool_use.get("name") or "unknown"
@@ -2031,7 +2059,7 @@ def emit_tool_observation_batch(
     pending_subagents: List[Dict[str, Any]],
     pending_async_tool_results: List[Dict[str, Any]],
     cursor: EmissionCursor,
-    workflow_agent_transcripts_by_run_id: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    workflow_agent_transcripts_by_run_id: Optional[WorkflowAgentTranscriptsByRunId] = None,
 ) -> EmittedToolObservationBatch:
     assistant_timestamp = parse_timestamp(assistant_message)
     generation_key = generation_emission_key(assistant_index, assistant_message)
@@ -2188,7 +2216,7 @@ def emit_turn_observations(langfuse: Langfuse, parent_otel_span: Any, turn: Turn
                            generation_name: str = "LLM Call",
                            subagent_transcripts_by_tool_use_id: Optional[Dict[str, Dict[str, Any]]] = None,
                            cursor: Optional[EmissionCursor] = None,
-                           workflow_agent_transcripts_by_run_id: Optional[Dict[str, List[Dict[str, Any]]]] = None) -> Optional[datetime]:
+                           workflow_agent_transcripts_by_run_id: Optional[WorkflowAgentTranscriptsByRunId] = None) -> Optional[datetime]:
     """Emit a turn's generations and tool observations under an existing span.
 
     The full turn is always walked so cross-observation context (generation
@@ -2647,7 +2675,7 @@ def emit_turn(langfuse: Langfuse, session_id: str, turn_num: int,
               close: bool = True,
               trace_seed: Optional[str] = None,
               parent_context: Optional[Tuple[str, str]] = None,
-              workflow_agent_transcripts_by_run_id: Optional[Dict[str, List[Dict[str, Any]]]] = None) -> Dict[str, Any]:
+              workflow_agent_transcripts_by_run_id: Optional[WorkflowAgentTranscriptsByRunId] = None) -> Dict[str, Any]:
     """Emit a turn, resuming from prior firings' progress.
 
     With no progress and close=True this is the classic one-shot emission.
@@ -2738,7 +2766,7 @@ def emit_and_close_ready_turns(
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
     trace_seed: Optional[str] = None,
     parent_context: Optional[Tuple[str, str]] = None,
-    workflow_agent_transcripts_by_run_id: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    workflow_agent_transcripts_by_run_id: Optional[WorkflowAgentTranscriptsByRunId] = None,
 ) -> int:
     emitted = 0
     # Turns without a user-row uuid bypass assign_turn_numbers; seed their
@@ -2789,7 +2817,7 @@ def emit_ready_observations_of_open_turn(
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]],
     trace_seed: Optional[str] = None,
     parent_context: Optional[Tuple[str, str]] = None,
-    workflow_agent_transcripts_by_run_id: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    workflow_agent_transcripts_by_run_id: Optional[WorkflowAgentTranscriptsByRunId] = None,
 ) -> None:
     """Emit the held open turn once its async activity is provably resolved.
 
@@ -2856,12 +2884,7 @@ def emit_new_turns_from_transcript(
         if subagent_transcripts_by_tool_use_id:
             debug(f"Discovered {len(subagent_transcripts_by_tool_use_id)} subagent transcript(s)")
 
-        workflow_agent_transcripts_by_run_id = get_workflow_agent_transcripts_by_run_id(transcript_path)
-        if workflow_agent_transcripts_by_run_id:
-            debug(
-                f"Discovered workflow agent transcript(s) for "
-                f"{len(workflow_agent_transcripts_by_run_id)} workflow run(s)"
-            )
+        workflow_agent_transcripts_by_run_id = WorkflowAgentTranscriptsByRunId(transcript_path)
 
         turns, session_state = get_new_turns_from_transcript(
             transcript_path,

--- a/tests/integration/test_workflow_subagent_emission.py
+++ b/tests/integration/test_workflow_subagent_emission.py
@@ -31,6 +31,45 @@ def ts_ns(hook_module: Any, iso_timestamp: str) -> int:
     return hook_module.to_otel_nanoseconds(hook_module.parse_timestamp(iso_timestamp))
 
 
+def record_scanned_run_dirs(hook_module: Any, monkeypatch: Any) -> list[str]:
+    """Record the run directories that an emission reads from disk.
+
+    The returned list stays live. Clear it between firings to limit an assertion
+    to one firing."""
+    scanned: list[str] = []
+    real_scan = hook_module.get_workflow_agents_in_run_dir
+
+    def recording_scan(run_dir: Path) -> Any:
+        scanned.append(run_dir.name)
+        return real_scan(run_dir)
+
+    monkeypatch.setattr(hook_module, "get_workflow_agents_in_run_dir", recording_scan)
+    return scanned
+
+
+def plain_turn_rows(index: int, minute: int) -> list[dict[str, Any]]:
+    """An ordinary turn of two rows. The session continues after a workflow."""
+    return [
+        {"type": "user", "timestamp": f"2026-07-23T10:{minute:02d}:00.000Z",
+         "sessionId": "session-workflow", "uuid": f"user-plain-{index}", "cwd": "/repo",
+         "gitBranch": "main", "origin": {"kind": "human"}, "parentUuid": None,
+         "permissionMode": "default", "promptId": f"prompt-plain-{index}",
+         "promptSource": "sdk", "entrypoint": "cli", "userType": "external",
+         "version": "2.1.215", "isSidechain": False,
+         "message": {"role": "user", "content": f"Plain question {index}?"}},
+        {"type": "assistant", "timestamp": f"2026-07-23T10:{minute:02d}:20.000Z",
+         "sessionId": "session-workflow", "uuid": f"assistant-plain-{index}",
+         "parentUuid": f"user-plain-{index}", "requestId": f"req-plain-{index}",
+         "entrypoint": "cli", "userType": "external", "version": "2.1.215",
+         "isSidechain": False,
+         "message": {"id": f"msg-plain-{index}", "type": "message", "role": "assistant",
+                     "model": "claude-test",
+                     "content": [{"type": "text", "text": f"Plain answer {index}."}],
+                     "stop_reason": "end_turn",
+                     "usage": {"input_tokens": 5, "output_tokens": 5}}},
+    ]
+
+
 # The last workflow-agent activity on disk (r2's trailing StructuredOutput
 # tool_result row): the only timestamp that can reach the tool/root span ends
 # via workflow_end_timestamp.
@@ -430,3 +469,124 @@ def test_workflow_launch_without_workflow_name_falls_back_to_run_id_labels(
     agent_spans = [o for o in fake_langfuse.observations if o.name.startswith("Workflow agent: ")]
     assert all(o._otel_span.parent is tool_span._otel_span for o in agent_spans)
     assert all("workflow_name" not in o.kwargs["metadata"] for o in agent_spans)
+
+
+def test_only_the_run_directory_the_turn_references_is_read(
+    hook_module,
+    fake_langfuse,
+    isolated_hook_state,
+    fixture_transcript_path,
+    tmp_path,
+    monkeypatch,
+):
+
+    transcript, rows = copy_workflow_fixture(fixture_transcript_path, tmp_path)
+    other_run_dir = tmp_path / "transcript" / "subagents" / "workflows" / "wf_test002"
+    other_run_dir.mkdir(parents=True)
+    (other_run_dir / "agent-x9.meta.json").write_text(
+        json.dumps({"agentType": "workflow-subagent", "spawnDepth": 1}), encoding="utf-8"
+    )
+    (other_run_dir / "agent-x9.jsonl").write_text("", encoding="utf-8")
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+    scanned = record_scanned_run_dirs(hook_module, monkeypatch)
+
+    append_rows(transcript, rows)
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-workflow-scope", transcript)
+
+    assert scanned == ["wf_test001"]
+
+
+def test_closed_workflow_turn_is_not_reread_by_later_firings(
+    hook_module,
+    fake_langfuse,
+    isolated_hook_state,
+    fixture_transcript_path,
+    tmp_path,
+    monkeypatch,
+):
+    transcript, rows = copy_workflow_fixture(fixture_transcript_path, tmp_path)
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+    scanned = record_scanned_run_dirs(hook_module, monkeypatch)
+
+    # Firing 1 resolves the workflow turn and emits its agents. This reads the
+    # run directory.
+    append_rows(transcript, rows)
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-workflow-closed", transcript)
+    assert scanned == ["wf_test001"]
+    assert len([o for o in fake_langfuse.observations if o.name.startswith("Workflow agent: ")]) == 2
+
+    # The workflow turn is still the open turn. The next turn completes it, and
+    # that close walks its rows once more and reads the run again.
+    scanned.clear()
+    append_rows(transcript, plain_turn_rows(1, 5))
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-workflow-closed", transcript)
+    assert scanned == ["wf_test001"]
+
+    # A closed turn never enters emission again, so its run directory, whose
+    # journal holds every agent's return value, is not read again.
+    scanned.clear()
+    for index, minute in ((2, 6), (3, 7), (4, 8)):
+        append_rows(transcript, plain_turn_rows(index, minute))
+        hook_module.emit_new_turns_from_transcript(
+            fake_langfuse, config, "session-workflow-closed", transcript
+        )
+
+    assert scanned == []
+    # No turn is a duplicate, and no turn is lost. The workflow turn and the
+    # four ordinary turns each reach Langfuse one time.
+    assert len([o for o in fake_langfuse.observations if o.name.startswith("Workflow agent: ")]) == 2
+    assert [o.name for o in fake_langfuse.observations].count("Conversational Turn") == 5
+
+
+def test_held_workflow_turn_defers_the_run_directory_read_too(
+    hook_module,
+    fake_langfuse,
+    isolated_hook_state,
+    fixture_transcript_path,
+    tmp_path,
+    monkeypatch,
+):
+    transcript, rows = copy_workflow_fixture(fixture_transcript_path, tmp_path)
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+    scanned = record_scanned_run_dirs(hook_module, monkeypatch)
+
+    append_rows(transcript, rows[:4])
+    for _ in range(3):
+        hook_module.emit_new_turns_from_transcript(
+            fake_langfuse, config, "session-workflow-held", transcript
+        )
+    assert fake_langfuse.observations == []
+    assert scanned == []
+
+    # An agent that comes to disk after those firings is still found. The lookup
+    # keeps a result for one firing only.
+    run_dir = tmp_path / "transcript" / "subagents" / "workflows" / "wf_test001"
+    (run_dir / "agent-r3.meta.json").write_text(
+        json.dumps({"agentType": "workflow-subagent", "spawnDepth": 1}), encoding="utf-8"
+    )
+    append_rows(run_dir / "agent-r3.jsonl", [
+        {"type": "user", "timestamp": "2026-07-23T10:01:00.000Z", "sessionId": "session-workflow",
+         "agentId": "r3", "uuid": "wf-r3-user-1", "parentUuid": None, "isSidechain": True,
+         "message": {"role": "user", "content": "Verify claim C."}},
+        {"type": "assistant", "timestamp": "2026-07-23T10:01:30.000Z", "sessionId": "session-workflow",
+         "agentId": "r3", "uuid": "wf-r3-assistant-1", "parentUuid": "wf-r3-user-1",
+         "isSidechain": True,
+         "message": {"id": "msg-wf-r3-1", "type": "message", "role": "assistant",
+                     "model": "claude-test",
+                     "content": [{"type": "text", "text": "Claim C holds."}],
+                     "stop_reason": "end_turn",
+                     "usage": {"input_tokens": 2, "output_tokens": 60}}},
+    ])
+
+    append_rows(transcript, rows[4:])
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-workflow-held", transcript)
+
+    assert scanned == ["wf_test001"]
+    agent_spans = sorted(
+        o.name for o in fake_langfuse.observations if o.name.startswith("Workflow agent: ")
+    )
+    assert agent_spans == [
+        "Workflow agent: verify-claims/r1",
+        "Workflow agent: verify-claims/r2",
+        "Workflow agent: verify-claims/r3",
+    ]

--- a/tests/unit/test_subagent_discovery.py
+++ b/tests/unit/test_subagent_discovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 
 
@@ -36,10 +37,9 @@ def test_discovers_nested_subagent_metadata_seen_in_real_claude_code_transcripts
 def test_discovers_workflow_agent_transcripts_by_run_id(hook_module, fixture_transcript_path):
     transcript = fixture_transcript_path("workflow_subagents")
 
-    workflows = hook_module.get_workflow_agent_transcripts_by_run_id(transcript)
+    lookup = hook_module.WorkflowAgentTranscriptsByRunId(transcript)
 
-    assert set(workflows) == {"wf_test001"}
-    agents = workflows["wf_test001"]
+    agents = lookup.get("wf_test001")
     # The journal also holds a started-row for "r3" with no result and no
     # meta/jsonl on disk (real partial-journal case: agent still running or
     # torn down early) — discovery is meta-driven, so r3 never surfaces.
@@ -51,12 +51,109 @@ def test_discovers_workflow_agent_transcripts_by_run_id(hook_module, fixture_tra
     assert agents[1]["result"] == {"verdict": "claim B holds", "confidence": "high"}
 
 
+def test_workflow_lookup_keeps_concurrent_runs_apart(hook_module, tmp_path):
+    # One firing can emit turns that use more than one run, so each run keeps
+    # its own entry.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    workflows_dir = tmp_path / "transcript" / "subagents" / "workflows"
+    for run_id, agent_id in (("wf_first", "f1"), ("wf_second", "s1")):
+        run_dir = workflows_dir / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / f"agent-{agent_id}.meta.json").write_text(
+            json.dumps({"agentType": "workflow-subagent", "spawnDepth": 1}), encoding="utf-8"
+        )
+        (run_dir / f"agent-{agent_id}.jsonl").write_text("", encoding="utf-8")
+        (run_dir / "journal.jsonl").write_text(
+            json.dumps({"type": "result", "key": "v2:abc", "agentId": agent_id,
+                        "result": {"run": run_id}}) + "\n",
+            encoding="utf-8",
+        )
+    lookup = hook_module.WorkflowAgentTranscriptsByRunId(transcript)
+
+    first = lookup.get("wf_first")
+    second = lookup.get("wf_second")
+
+    assert [agent["agent_id"] for agent in first] == ["f1"]
+    assert [agent["agent_id"] for agent in second] == ["s1"]
+    assert first[0]["result"] == {"run": "wf_first"}
+    assert second[0]["result"] == {"run": "wf_second"}
+    # A second lookup of each run gives the agents of that run.
+    assert lookup.get("wf_first") is first
+    assert lookup.get("wf_second") is second
+
+
+def test_workflow_lookup_finds_a_run_directory_without_the_wf_prefix(hook_module, tmp_path):
+    # The run id names the directory, so a name without the earlier "wf_" glob
+    # pattern resolves too. This is wider on purpose.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    run_dir = tmp_path / "transcript" / "subagents" / "workflows" / "run_abc"
+    run_dir.mkdir(parents=True)
+    (run_dir / "agent-n1.meta.json").write_text(
+        json.dumps({"agentType": "workflow-subagent", "spawnDepth": 1}), encoding="utf-8"
+    )
+    (run_dir / "agent-n1.jsonl").write_text("", encoding="utf-8")
+
+    agents = hook_module.WorkflowAgentTranscriptsByRunId(transcript).get("run_abc")
+
+    assert [agent["agent_id"] for agent in agents] == ["n1"]
+
+
+def test_workflow_lookup_memoizes_run_ids_that_have_no_agents(
+    hook_module,
+    tmp_path,
+    monkeypatch,
+):
+    # A run directory can be absent. The lookup must keep that empty result too,
+    # or each observation that uses the run makes a new read.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    scanned: list[str] = []
+    monkeypatch.setattr(
+        hook_module,
+        "get_workflow_agents_in_run_dir",
+        lambda run_dir: scanned.append(run_dir.name) or [],
+    )
+    lookup = hook_module.WorkflowAgentTranscriptsByRunId(transcript)
+
+    assert lookup.get("wf_gone") is None
+    assert lookup.get("wf_gone") is None
+    assert scanned == ["wf_gone"]
+
+
+def test_workflow_lookup_rejects_run_ids_that_leave_the_workflows_directory(
+    hook_module,
+    fixture_transcript_path,
+    monkeypatch,
+):
+    # The lookup makes a path from transcript data, so only a plain directory
+    # name must resolve, and a rejected run id must cause no read.
+    transcript = fixture_transcript_path("workflow_subagents")
+    scanned: list[str] = []
+    monkeypatch.setattr(
+        hook_module,
+        "get_workflow_agents_in_run_dir",
+        lambda run_dir: scanned.append(str(run_dir)) or [],
+    )
+    lookup = hook_module.WorkflowAgentTranscriptsByRunId(transcript)
+
+    for hostile_run_id in ("..", "../wf_test001", "wf_test001/..", "nested/wf_test001",
+                           "/etc", ".", "wf_test001/"):
+        assert lookup.get(hostile_run_id) is None, hostile_run_id
+    # An absent or incorrect run id also gives None, and makes no file read.
+    assert lookup.get(None) is None
+    assert lookup.get("") is None
+    assert lookup.get(123) is None
+    assert scanned == []
+
+
 def test_workflow_agents_stay_invisible_to_classic_subagent_discovery(
     hook_module,
     fixture_transcript_path,
 ):
     # Documented split: the classic function keys strictly by toolUseId and
-    # stays non-recursive; workflow agents are only reachable via the new map.
+    # stays non-recursive. Only the run-id lookup finds workflow agents.
     transcript = fixture_transcript_path("workflow_subagents")
 
     assert hook_module.get_subagent_transcripts_by_tool_use_id(transcript) == {}
@@ -78,7 +175,7 @@ def test_workflow_discovery_ignores_bad_or_foreign_metadata(hook_module, tmp_pat
         encoding="utf-8",
     )
 
-    assert hook_module.get_workflow_agent_transcripts_by_run_id(transcript) == {}
+    assert hook_module.WorkflowAgentTranscriptsByRunId(transcript).get("wf_x1") is None
 
 
 def test_workflow_discovery_drops_run_dirs_with_journal_but_no_agents(hook_module, tmp_path):
@@ -94,7 +191,7 @@ def test_workflow_discovery_drops_run_dirs_with_journal_but_no_agents(hook_modul
         encoding="utf-8",
     )
 
-    assert hook_module.get_workflow_agent_transcripts_by_run_id(transcript) == {}
+    assert hook_module.WorkflowAgentTranscriptsByRunId(transcript).get("wf_journal_only") is None
 
 
 def test_workflow_discovery_ignores_orphan_agent_jsonl_without_meta(hook_module, tmp_path):
@@ -110,7 +207,7 @@ def test_workflow_discovery_ignores_orphan_agent_jsonl_without_meta(hook_module,
         encoding="utf-8",
     )
 
-    assert hook_module.get_workflow_agent_transcripts_by_run_id(transcript) == {}
+    assert hook_module.WorkflowAgentTranscriptsByRunId(transcript).get("wf_orphan") is None
 
 
 def test_workflow_discovery_accepts_metas_with_extra_real_world_keys(hook_module, tmp_path):
@@ -135,11 +232,10 @@ def test_workflow_discovery_accepts_metas_with_extra_real_world_keys(hook_module
     )
     (run_dir / "agent-a1.jsonl").write_text("", encoding="utf-8")
 
-    workflows = hook_module.get_workflow_agent_transcripts_by_run_id(transcript)
+    agents = hook_module.WorkflowAgentTranscriptsByRunId(transcript).get("wf_x3")
 
-    assert set(workflows) == {"wf_x3"}
-    assert workflows["wf_x3"][0]["agent_id"] == "a1"
-    assert workflows["wf_x3"][0]["agent_type"] == "workflow-subagent"
+    assert [agent["agent_id"] for agent in agents] == ["a1"]
+    assert agents[0]["agent_type"] == "workflow-subagent"
 
 
 def test_workflow_discovery_without_journal_leaves_results_empty(hook_module, tmp_path):
@@ -153,11 +249,28 @@ def test_workflow_discovery_without_journal_leaves_results_empty(hook_module, tm
     )
     (run_dir / "agent-a1.jsonl").write_text("", encoding="utf-8")
 
-    workflows = hook_module.get_workflow_agent_transcripts_by_run_id(transcript)
+    agents = hook_module.WorkflowAgentTranscriptsByRunId(transcript).get("wf_x2")
 
-    assert set(workflows) == {"wf_x2"}
-    assert workflows["wf_x2"][0]["agent_id"] == "a1"
-    assert workflows["wf_x2"][0]["result"] is None
+    assert [agent["agent_id"] for agent in agents] == ["a1"]
+    assert agents[0]["result"] is None
+
+
+def test_workflow_lookup_survives_a_run_directory_the_filesystem_rejects(
+    hook_module,
+    tmp_path,
+    monkeypatch,
+):
+    # The hook runs in the Stop path of Claude Code. Thus a run path that the
+    # operating system refuses must not stop the turn.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("", encoding="utf-8")
+
+    def raise_name_too_long(_run_dir):
+        raise OSError(errno.ENAMETOOLONG, "File name too long")
+
+    monkeypatch.setattr(hook_module, "get_workflow_agents_in_run_dir", raise_name_too_long)
+
+    assert hook_module.WorkflowAgentTranscriptsByRunId(transcript).get("wf_x") is None
 
 
 def test_ignores_bad_or_incomplete_subagent_metadata(hook_module, tmp_path):


### PR DESCRIPTION
Follow-up to #45

Discovery ran on every hook firing, before the transcript was even parsed: it globbed every `wf_*` run directory and re-read each run's `journal.jsonl` (which holds every agent's full return value) plus every agent meta, also for firings that reference no workflow, and for runs closed long ago.

## What changed

* `get_workflow_agents_in_run_dir(run_dir)` scans one run directory instead of building a map of all of them.
* `WorkflowAgentTranscriptsByRunId.get(run_id)` reads a run on first lookup and keeps it for that firing. Construction does no I/O; the memo dies with the firing, so a still-running workflow is read fresh next time.
* Emission is untouched — the consumer line is unchanged from `main`. Reads happen at emission time, for referenced runs only.
* Run ids become a path now, so `get()` accepts only a plain directory name and an unreadable path degrades to "no agents" (without that guard, an over-long run id truncates the turn and duplicates its root on every later firing).
* Side effect, pinned by a test: a run directory not matching `wf_*` is discoverable now, since the run id addresses it directly.

## Numbers

3 runs × 40 agents, 2 KB results, 50 ordinary firings after the workflow turns closed:

| | before | after |
|---|---|---|
| bytes read under `workflows/` | 14.0 MB | 94 KB |
| time per ordinary firing | 4.65 ms | 0.38 ms |
| observations emitted | 355 | 355 |

## Verification

176 tests (168 before) on the repo venv and Python 3.10 · every fixture replayed row by row plus SessionEnd: observations byte-identical to `main` · 6 mutations of the new guarantees all caught · hostile filesystem states and run ids: no crash, identical emission · end-to-end differential against a local Langfuse server: identical trace trees.

Refs LFE-15010.