### PR TITLE
chore(hook): align the Langfuse SDK pin with the documented v4 minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Get keys from your Langfuse project settings → API Keys.
 One of:
 
 - [uv](https://docs.astral.sh/uv/) (recommended) on `PATH`. The hook uses `uv run --script` and installs the Langfuse SDK from the script metadata automatically.
-- Python 3.10+ as `python3` with `langfuse>=4.0,<5` installed in that Python environment. This is only used as a fallback when `uv` is not on `PATH`.
+- Python 3.10+ as `python3` with `langfuse>=4.7,<5` installed in that Python environment. This is only used as a fallback when `uv` is not on `PATH`.
 
 On the first hook run, uv downloads the Langfuse SDK from PyPI (declared in the script header) and caches it. Offline or proxied machines fail this download and retry on every turn until the cache is warm; you can pre-warm it from a networked terminal:
 
@@ -215,7 +215,7 @@ Nearly every failure explains itself in `~/.claude/state/langfuse_hook.log` (wit
 | What the log shows | Meaning | What to do |
 | --- | --- | --- |
 | No new lines at all | The hook never launched. Either the plugin is disabled, no usable runtime was found (no `uv`, no suitable `python3`), or uv could not download the SDK (offline/proxy) | Run `claude plugin list` **from the directory you use in the app**, since enable/disable can be project-scoped. Install uv and make sure it is on the PATH of the app that launches Claude Code. Pre-warm the SDK download (see Requirements) |
-| `langfuse import failed (…) python=… PATH=…` | The Python that ran the hook cannot import the SDK; the line names the interpreter, version, and PATH | Install uv and make sure it is on the PATH the hook inherits (the log line shows that PATH), or make sure `python3` is 3.10+ with `langfuse>=4.0,<5` installed |
+| `langfuse import failed (…) python=… PATH=…` | The Python that ran the hook cannot import the SDK; the line names the interpreter, version, and PATH | Install uv and make sure it is on the PATH the hook inherits (the log line shows that PATH), or make sure `python3` is 3.10+ with `langfuse>=4.7,<5` installed |
 | `Langfuse config incomplete: missing …` | The named key(s) did not reach the hook. Either not configured yet, or configured but not delivered | Configure via `/plugin configure`. If the line also says `loaded under plugin identity '@inline'`, see the desktop section below |
 | `Hook started` plus a skip reason (e.g. `Transcript path does not exist`) | The hook ran and skipped intentionally; these often come from background/utility sessions | Usually harmless. File an issue with the log line if actual turns are missing |
 | `Processed N turns …` but nothing in Langfuse | Turns were handed to the SDK but delivery failed afterwards; export errors go to stderr, not this log | Check `LANGFUSE_BASE_URL` (EU `https://cloud.langfuse.com` vs US `https://us.cloud.langfuse.com`), key validity, and network/proxy reachability |

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "langfuse>=4.0,<5",
+#   "langfuse>=4.7,<5",
 # ]
 # ///
 """
@@ -1663,7 +1663,7 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
         raise RuntimeError(
             f"Langfuse SDK {sdk_version} is missing _otel_tracer or "
             f"_create_observation_from_otel_span. This hook targets SDK 4.x; "
-            f"pin with `pip install \"langfuse>=4.0,<5\"` or update the hook script."
+            f"pin with `pip install \"langfuse>=4.7,<5\"` or update the hook script."
         )
     start_ns = to_otel_nanoseconds(start_time)
     if parent_otel_span is not None:


### PR DESCRIPTION
## Summary

Langfuse v4 documents Python SDK **4.7.0** as the minimum for the new data model;
the hook declared `langfuse>=4.0,<5`. This aligns the script header, the
internals-guard hint, and the two README lines documenting the `python3` fallback
install with that minimum.

No behavior change, and no defect below 4.7 that we could reproduce — `uv run
--script` resolves to the newest 4.x either way. The README lines are the
substantive part: the `python3` fallback does not read the script header, so the
README is the only install instruction on that path, and it pointed below the
documented minimum.

Context for the linked issue: this plugin never used the legacy batch ingestion
API that Langfuse Cloud removes on 2026-11-16 (dropped in af1f49d; emission is
pure SDK spans), so there is no v4 migration for it — tracing against a v4 Cloud
project works today. 183 tests unchanged.

Refs langfuse/claude-observability-plugin#59