### PR TITLE
fix(hook): attribute named-teammate subagent transcripts

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -971,7 +971,10 @@ def get_async_launch_flag_from_row(row: Dict[str, Any]) -> Optional[bool]:
     tool_use_result = row.get("toolUseResult")
     if not isinstance(tool_use_result, dict):
         return None
-    return tool_use_result.get("status") == "async_launched" or tool_use_result.get("isAsync") is True
+    # A teammate launch is async too: its result never carries the final output.
+    if tool_use_result.get("status") in ("async_launched", "teammate_spawned"):
+        return True
+    return tool_use_result.get("isAsync") is True
 
 def get_workflow_launch_marker_from_row(row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Read the structured Workflow launch marker from a tool_result row.
@@ -1432,27 +1435,77 @@ def resolve_agent_jsonl_and_id(meta_path: Path) -> Optional[Tuple[Path, str]]:
         agent_id = agent_id[len("agent-"):]
     return jsonl_path, agent_id
 
+def get_agent_launch_tool_use_ids_by_name(transcript_path: Path) -> Dict[str, str]:
+    """Map each agent name to the tool_use id of its launch.
+    The function streams the full transcript. It removes ambiguous names."""
+    mapping: Dict[str, str] = {}
+    ambiguous: set = set()
+    try:
+        with transcript_path.open(encoding="utf-8") as lines:
+            for line in lines:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                for tool_use in get_tool_use_blocks(get_content_from_row(row)):
+                    tool_use_id = str(tool_use.get("id") or "")
+                    tool_input = tool_use.get("input")
+                    if tool_use.get("name") not in ("Agent", "Task") or not tool_use_id:
+                        continue
+                    name = tool_input.get("name") if isinstance(tool_input, dict) else None
+                    if not isinstance(name, str) or not name:
+                        continue
+                    if mapping.get(name, tool_use_id) != tool_use_id:
+                        ambiguous.add(name)
+                    mapping[name] = tool_use_id
+    except Exception:
+        return {}
+    return {name: tool_use_id for name, tool_use_id in mapping.items() if name not in ambiguous}
+
 def get_subagent_transcripts_by_tool_use_id(transcript_path: Path) -> Dict[str, Dict[str, Any]]:
     """Map launching Agent/Task tool_use ids to their subagent transcripts."""
     subagent_dir = transcript_path.with_suffix("") / "subagents"
     if not subagent_dir.is_dir():
         return {}
 
+    # Build the fallback map only when a meta has no toolUseId.
+    fallback_tool_use_ids: Optional[Dict[str, str]] = None
+    claimed_twice: set = set()
     subagent_transcripts_by_tool_use_id: Dict[str, Dict[str, Any]] = {}
-    for meta_path in subagent_dir.glob("*.meta.json"):
+    for meta_path in sorted(subagent_dir.glob("*.meta.json")):
         try:
             metadata = json.loads(meta_path.read_text(encoding="utf-8"))
         except Exception:
             continue
-
-        tool_use_id = metadata.get("toolUseId")
-        if not isinstance(tool_use_id, str) or not tool_use_id:
+        if not isinstance(metadata, dict):
             continue
 
         resolved = resolve_agent_jsonl_and_id(meta_path)
         if resolved is None:
             continue
         jsonl_path, agent_id = resolved
+
+        tool_use_id = metadata.get("toolUseId")
+        if not isinstance(tool_use_id, str) or not tool_use_id:
+            if fallback_tool_use_ids is None:
+                fallback_tool_use_ids = get_agent_launch_tool_use_ids_by_name(transcript_path)
+            # A teammate meta carries the launch input.name.
+            name = metadata.get("name")
+            tool_use_id = fallback_tool_use_ids.get(name) if isinstance(name, str) else None
+        if not tool_use_id:
+            info(f"subagent transcript not attributable to a launching tool_use, skipping: {meta_path}")
+            continue
+        if tool_use_id in claimed_twice or tool_use_id in subagent_transcripts_by_tool_use_id:
+            # Two metas claim one launch -> Drop both.
+            claimed_twice.add(tool_use_id)
+            subagent_transcripts_by_tool_use_id.pop(tool_use_id, None)
+            info(f"multiple subagent metas claim tool_use {tool_use_id}, skipping: {meta_path}")
+            continue
 
         subagent_transcripts_by_tool_use_id[tool_use_id] = {
             "path": jsonl_path,

--- a/tests/integration/test_emit_new_turns_from_transcript.py
+++ b/tests/integration/test_emit_new_turns_from_transcript.py
@@ -140,6 +140,91 @@ def test_open_agent_turn_emits_only_after_notification_delivery(
     assert len(roots()) == 1
 
 
+def test_named_teammate_transcript_attaches_to_its_launch_at_session_end_flush(
+    hook_module,
+    fake_langfuse,
+    isolated_hook_state,
+    tmp_path,
+):
+    """A teammate meta has no toolUseId. The launch input.name
+    attributes its transcript when the deferred turn flushes at SessionEnd."""
+    transcript = tmp_path / "transcript.jsonl"
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+    # Meta and launch shapes below are harvested from a real 2.1.238 team session.
+    (subagent_dir / "agent-abuilder-issue-4-03b96faf.meta.json").write_text(
+        json.dumps({
+            "agentType": "builder-issue-4",
+            "description": "Build issue 4",
+            "name": "builder-issue-4",
+            "spawnDepth": 0,
+            "model": "sonnet",
+            "taskKind": "in_process_teammate",
+            "teamName": "session-test",
+            "color": "blue",
+            "planModeRequired": False,
+            "permissionMode": "default",
+        }),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-abuilder-issue-4-03b96faf.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in [
+            {"type": "user", "uuid": "builder-user-1", "timestamp": "2026-01-01T00:00:03.000Z",
+             "message": {"role": "user", "content": "Build the fix."}},
+            {"type": "assistant", "uuid": "builder-assistant-1", "timestamp": "2026-01-01T00:00:06.000Z",
+             "message": {"id": "msg-builder-1", "role": "assistant", "model": "claude-test",
+                         "content": [{"type": "text", "text": "Patch ready."}],
+                         "usage": {"input_tokens": 12, "output_tokens": 34}}},
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    launch_rows = [
+        {"type": "user", "uuid": "user-1", "timestamp": "2026-01-01T00:00:00.000Z",
+         "sessionId": "session-teammate", "message": {"role": "user", "content": "Start a teammate."}},
+        {"type": "assistant", "uuid": "assistant-1", "timestamp": "2026-01-01T00:00:01.000Z",
+         "message": {"id": "msg-1", "role": "assistant", "model": "claude-test",
+                     "content": [{"type": "tool_use", "id": "toolu_builder", "name": "Agent",
+                                  "input": {"name": "builder-issue-4",
+                                            "taskKind": "in_process_teammate",
+                                            "prompt": "Build the fix."}}]}},
+        {"type": "user", "uuid": "tool-result-1", "timestamp": "2026-01-01T00:00:02.000Z",
+         "toolUseResult": {"status": "teammate_spawned", "name": "builder-issue-4",
+                           "agent_id": "builder-issue-4@session-test",
+                           "teammate_id": "builder-issue-4@session-test",
+                           "agent_type": "general-purpose", "team_name": "session-test"},
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "toolu_builder",
+              "content": [{"type": "text", "text": "Spawned successfully. agent_id: builder-issue-4@session-test"}]}]}},
+        {"type": "assistant", "uuid": "assistant-2", "timestamp": "2026-01-01T00:00:02.500Z",
+         "message": {"id": "msg-2", "role": "assistant", "model": "claude-test",
+                     "content": [{"type": "text", "text": "The teammate is running."}]}},
+    ]
+    transcript.write_text("\n".join(json.dumps(row) for row in launch_rows) + "\n", encoding="utf-8")
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+
+    # First Stop: a teammate sends no task-notification. The hook emits nothing.
+    hook_module.emit_new_turns_from_transcript(fake_langfuse, config, "session-teammate", transcript)
+    assert fake_langfuse.observations == []
+
+    # SessionEnd: the hook flushes the deferred turn with the teammate transcript.
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config, "session-teammate", transcript, flush_deferred_agent_turns=True,
+    )
+
+    names = [observation.name for observation in fake_langfuse.observations]
+    assert "Conversational Turn" in names
+    assert "Tool: Agent" in names
+    assert "Subagent: Build issue 4" in names
+    teammate_span = next(o for o in fake_langfuse.observations if o.name == "Subagent: Build issue 4")
+    # Real teammate metas set agentType to the teammate name (config/launch
+    # result say "general-purpose"; the meta does not).
+    assert teammate_span.kwargs["metadata"]["agent_type"] == "builder-issue-4"
+    assert teammate_span.output == {"role": "assistant", "content": "Patch ready."}
+    # The trace contains the teammate tokens. 
+    teammate_generation = next(o for o in fake_langfuse.observations if o.name == "Subagent LLM Call")
+    assert teammate_generation.kwargs["usage_details"] == {"input": 12, "output": 34}
+
+
 def test_only_the_turn_root_span_is_marked_as_root(
     hook_module,
     fixture_transcript_path,

--- a/tests/unit/test_subagent_discovery.py
+++ b/tests/unit/test_subagent_discovery.py
@@ -159,6 +159,183 @@ def test_workflow_agents_stay_invisible_to_classic_subagent_discovery(
     assert hook_module.get_subagent_transcripts_by_tool_use_id(transcript) == {}
 
 
+def test_discovers_named_teammate_meta_without_tool_use_id_via_launch_input_name(hook_module, tmp_path):
+    # A teammate meta has no toolUseId. Only input.name can attribute it.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({
+            "type": "assistant",
+            "timestamp": "2026-01-01T00:00:01.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_builder",
+                        "name": "Agent",
+                        "input": {
+                            "name": "builder-issue-4",
+                            "taskKind": "in_process_teammate",
+                            "prompt": "Build the fix",
+                        },
+                    },
+                ],
+            },
+        }) + "\n",
+        encoding="utf-8",
+    )
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+    # Real teammate file stems are "agent-a<name>-<hex>". The stem never matches a launch.
+    (subagent_dir / "agent-abuilder-issue-4-03b96faf.meta.json").write_text(
+        json.dumps({
+            "agentType": "builder-issue-4",
+            "description": "Build issue 4",
+            "name": "builder-issue-4",
+            "spawnDepth": 0,
+            "model": "sonnet",
+            "taskKind": "in_process_teammate",
+            "teamName": "session-test",
+        }),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-abuilder-issue-4-03b96faf.jsonl").write_text("", encoding="utf-8")
+
+    subagents = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
+
+    assert set(subagents) == {"toolu_builder"}
+    assert subagents["toolu_builder"]["agent_id"] == "abuilder-issue-4-03b96faf"
+    assert subagents["toolu_builder"]["agent_type"] == "builder-issue-4"
+    assert subagents["toolu_builder"]["description"] == "Build issue 4"
+
+
+def test_named_teammate_fallback_ignores_ambiguous_names(hook_module, tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    rows = [
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "toolu_one", "name": "Agent", "input": {"name": "builder"}}
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "toolu_two", "name": "Agent", "input": {"name": "builder"}}
+                ],
+            },
+        },
+    ]
+    transcript.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+    (subagent_dir / "agent-builder.meta.json").write_text(
+        json.dumps({"agentType": "builder", "name": "builder", "taskKind": "in_process_teammate"}),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-builder.jsonl").write_text("", encoding="utf-8")
+
+    assert hook_module.get_subagent_transcripts_by_tool_use_id(transcript) == {}
+
+
+def test_reused_teammate_name_drops_both_transcripts(hook_module, tmp_path):
+    # Real teammate launch results carry no per-spawn key (snake_case agent_id is
+    # "<name>@<team>"). A reused name is ambiguous, so both metas are skipped.
+    rows = [
+        {"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_first", "name": "Agent", "input": {"name": "builder"}}]}},
+        {"type": "user", "toolUseResult": {"status": "teammate_spawned", "agent_id": "builder@session-x",
+                                           "teammate_id": "builder@session-x", "name": "builder"},
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "toolu_first",
+              "content": "Spawned successfully. agent_id: builder@session-x"}]}},
+        {"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_second", "name": "Agent", "input": {"name": "builder"}}]}},
+        {"type": "user", "toolUseResult": {"status": "teammate_spawned", "agent_id": "builder@session-x",
+                                           "teammate_id": "builder@session-x", "name": "builder"},
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "toolu_second",
+              "content": "Spawned successfully. agent_id: builder@session-x"}]}},
+    ]
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+    for stem in ("abuilder-11111111", "abuilder-22222222"):
+        (subagent_dir / f"agent-{stem}.meta.json").write_text(
+            json.dumps({"agentType": "builder", "name": "builder", "taskKind": "in_process_teammate"}),
+            encoding="utf-8",
+        )
+        (subagent_dir / f"agent-{stem}.jsonl").write_text("", encoding="utf-8")
+
+    assert hook_module.get_subagent_transcripts_by_tool_use_id(transcript) == {}
+
+
+def test_two_metas_claiming_one_launch_drop_both(hook_module, tmp_path):
+    # A stale meta and a live one can share a name while only one launch row
+    # exists. Attribution is unknowable, so neither meta may win.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_only", "name": "Agent", "input": {"name": "reviewer"}}]}}) + "\n",
+        encoding="utf-8",
+    )
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+    for stem in ("areviewer-11111111", "areviewer-22222222"):
+        (subagent_dir / f"agent-{stem}.meta.json").write_text(
+            json.dumps({"agentType": "reviewer", "name": "reviewer", "taskKind": "in_process_teammate"}),
+            encoding="utf-8",
+        )
+        (subagent_dir / f"agent-{stem}.jsonl").write_text("", encoding="utf-8")
+
+    assert hook_module.get_subagent_transcripts_by_tool_use_id(transcript) == {}
+
+
+def test_non_dict_meta_is_skipped_without_crashing(hook_module, tmp_path):
+    # A meta holding a JSON array raised AttributeError before the dict guard.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+    (subagent_dir / "agent-broken.meta.json").write_text('["not", "a", "dict"]', encoding="utf-8")
+    (subagent_dir / "agent-broken.jsonl").write_text("", encoding="utf-8")
+    (subagent_dir / "agent-ok.meta.json").write_text(
+        json.dumps({"agentType": "general-purpose", "toolUseId": "toolu_ok", "spawnDepth": 1}),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-ok.jsonl").write_text("", encoding="utf-8")
+
+    assert set(hook_module.get_subagent_transcripts_by_tool_use_id(transcript)) == {"toolu_ok"}
+
+
+def test_unattributable_teammate_meta_does_not_break_classic_discovery(hook_module, tmp_path):
+    # A meta with no match must not stop classic discovery in the same directory.
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("", encoding="utf-8")
+    subagent_dir = tmp_path / "transcript" / "subagents"
+    subagent_dir.mkdir(parents=True)
+    (subagent_dir / "agent-classic.meta.json").write_text(
+        json.dumps({"agentType": "general-purpose", "toolUseId": "toolu_classic", "spawnDepth": 1}),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-classic.jsonl").write_text("", encoding="utf-8")
+    (subagent_dir / "agent-orphan.meta.json").write_text(
+        json.dumps({"agentType": "orphan", "name": "orphan", "taskKind": "in_process_teammate"}),
+        encoding="utf-8",
+    )
+    (subagent_dir / "agent-orphan.jsonl").write_text("", encoding="utf-8")
+
+    subagents = hook_module.get_subagent_transcripts_by_tool_use_id(transcript)
+
+    assert set(subagents) == {"toolu_classic"}
+
+
 def test_workflow_discovery_ignores_bad_or_foreign_metadata(hook_module, tmp_path):
     transcript = tmp_path / "transcript.jsonl"
     transcript.write_text("", encoding="utf-8")


### PR DESCRIPTION
Fixes #28. Linear: [LFE-14298](https://linear.app/clickhouse/issue/LFE-14298/named-teammate-agents-agent-teams-are-silently-invisible-metajson-has).

## The problem

Claude Code writes one `meta.json` file for each subagent. For a named teammate, that file has no `toolUseId` key. The launch result also gives `status: "teammate_spawned"`. It does not give `async_launched`.

The hook uses `toolUseId` to connect a transcript to its parent turn. If the key is absent, the hook skips the transcript. The hook writes no message about the skip.

The hook also does not hold the turn open. It emits the `Tool: Agent` span while the teammate does its work. That span is then immutable. The teammate transcript cannot attach to it later.

## The change

- `get_subagent_transcripts_by_tool_use_id`: if a meta has no `toolUseId`, the function matches the meta `name` against the `name` in the launching `Agent` or `Task` call. It builds this map only when such a meta exists. It streams the transcript in one pass.
- `get_async_launch_flag_from_row`: the function accepts `teammate_spawned` as an async launch. The turn then stays open. It flushes at SessionEnd with the complete transcript.
- Safety: the function removes ambiguous names. It also removes two metas that claim one launch. The glob is sorted, so the result is deterministic. A meta that is not a dictionary no longer causes an error. The hook writes an `info` message for each meta that it cannot attribute.

## The tests

A real `in_process_teammate` session on Claude Code 2.1.238 with three teammates gives the ground truth. Discovery attributes 3 of 3 teammates.

The test machine holds 535 classic metas. The result for these metas does not change, because the new path runs only when `toolUseId` is absent.

All 198 tests pass.

## Not in this change

Teammate spans appear at SessionEnd. They do not appear at each hook firing. An earlier emission truncates the span, because the transcript continues to grow.

Two items remain for later work: incremental teammate emission, and a memoized read of the transcript (compare #64). This change does not touch the `<teammate-message>` deferral.

