### PR TITLE
fix(plugin): bump the version so updates reach installed users

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse-observability",
   "description": "The Langfuse x Claude Code Observability Plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Langfuse"
   },


### PR DESCRIPTION
Linear: [LFE-14887](https://linear.app/clickhouse/issue/LFE-14887/claude-plugin-update-reports-already-at-the-latest-version-pluginjson)

## What

Bumps `.claude-plugin/plugin.json` from `1.0.0` to `1.1.0`.

## Why

Claude Code uses `plugin.json`'s `version` as the install cache key
(`~/.claude/plugins/cache/{marketplace}/{plugin}/{version}/`). While that field
stays unchanged, `claude plugin update` reports *"already at the latest
version"* and leaves the installed copy untouched, however far ahead `main` has
moved.

The field stayed at `1.0.0` across 103 commits, so users have been stranded on
whatever commit they happened to install. In #51 a stranded install measured
907 lines of `hooks/langfuse_hook.py` against 2675 on `main` at the time.

This is also the likely explanation for #67: the diagnosis there matches the
code as it stood between 2026-07-08 and 2026-07-17, i.e. before `53bcf45`
landed essentially the fix that issue proposes.

## For the release notes

Trace and observation names have changed since `1.0.0` — a constant trace name,
and `LLM Call` without a trailing number. Saved Langfuse views and name-based
filters need updating. Worth calling out explicitly, because `1.1.0` does not
signal it in the version number.

Auto-update is off by default for marketplaces outside Anthropic's, so this
release does not install itself. Users have to run:

```bash
claude plugin marketplace update langfuse-observability
claude plugin update langfuse-observability@langfuse-observability
```

## Follow-up

A second PR adds CI: pytest on the 3.10/3.13 matrix, plus a guard that fails
any PR touching `hooks/` without a version bump — so this cannot silently rot
again. Kept separate so it does not block this one.

Refs #51
