### PR TITLE
Add the emitting host to trace metadata

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import random
+import socket
 import sys
 import threading
 import time
@@ -1953,6 +1954,18 @@ def get_tool_result_for_observation(tool_result_entry: Any) -> ToolResultForObse
         final_result_timestamp=final_result_timestamp,
     )
 
+def get_hostname_for_metadata() -> Optional[str]:
+    """The machine this trace is emitted from, or None if it cannot be read.
+
+    Deliberately never raises. A trace missing a hostname is worth more than a
+    hook that dies while building metadata, and this runs on every turn.
+    """
+    try:
+        return socket.gethostname() or None
+    except OSError:
+        return None
+
+
 def get_short_transcript_path_for_metadata(path: Any) -> Optional[str]:
     if isinstance(path, Path):
         return path.name
@@ -2666,6 +2679,19 @@ def build_trace_metadata(
         value = turn.user_msg.get(src_key)
         if isinstance(value, str) and value:
             trace_metadata[dst_key] = value
+    # ...and the same goal needs the machine, because a project path is not
+    # unique across hosts: two machines sharing a checkout layout produce
+    # byte-identical `cwd`, so their traces are indistinguishable in Langfuse.
+    #
+    # Read at hook time, not from the transcript, because transcript rows carry
+    # no host field. So this names the host that EMITTED the trace -- the host
+    # that ran the session in the normal case, but NOT when a stored transcript
+    # is re-processed elsewhere (a backfill, or one copied to another machine
+    # for debugging). If Claude Code ever records a host in the transcript,
+    # prefer that and keep this as the fallback.
+    hostname = get_hostname_for_metadata()
+    if hostname:
+        trace_metadata["hostname"] = hostname
     return trace_metadata
 
 def is_valid_span_id_hex(span_id: Any) -> bool:

--- a/tests/unit/test_langfuse_payload_builders.py
+++ b/tests/unit/test_langfuse_payload_builders.py
@@ -115,6 +115,66 @@ def test_trace_metadata_includes_session_turn_project_and_branch(
     assert metadata["git_branch"] == "feature/test"
 
 
+def test_trace_metadata_names_the_emitting_host(
+    hook_module,
+    fixture_transcript_path,
+    read_fixture_jsonl,
+):
+    """`cwd` alone cannot separate two machines that share a checkout layout.
+
+    Two hosts with the same project path emit byte-identical `cwd`, so their
+    traces are indistinguishable in Langfuse -- which defeats the stated goal
+    of the sibling fields above on any multi-machine setup.
+    """
+    import socket
+
+    rows = read_fixture_jsonl(fixture_transcript_path("simple_turn"))
+    turn = hook_module.build_turns(rows)[0]
+
+    metadata = hook_module.build_trace_metadata(
+        "12345678-abcd-4000-8000-123456789abc",
+        7,
+        turn,
+        fixture_transcript_path("simple_turn"),
+        {"truncated": False},
+    )
+
+    assert metadata["hostname"] == socket.gethostname()
+
+
+def test_trace_metadata_survives_an_unreadable_hostname(
+    hook_module,
+    fixture_transcript_path,
+    read_fixture_jsonl,
+    monkeypatch,
+):
+    """A hostname that cannot be read must cost the field, never the trace.
+
+    This runs on every turn, so an exception here would take out observability
+    entirely rather than degrade it. Watched failing: without the guard in
+    `get_hostname_for_metadata`, this test raises instead of skipping the key.
+    """
+    monkeypatch.setattr(
+        hook_module.socket,
+        "gethostname",
+        lambda: (_ for _ in ()).throw(OSError("no hostname")),
+    )
+
+    rows = read_fixture_jsonl(fixture_transcript_path("simple_turn"))
+    turn = hook_module.build_turns(rows)[0]
+
+    metadata = hook_module.build_trace_metadata(
+        "12345678-abcd-4000-8000-123456789abc",
+        7,
+        turn,
+        fixture_transcript_path("simple_turn"),
+        {"truncated": False},
+    )
+
+    assert "hostname" not in metadata
+    assert metadata["cwd"] == "/repo"
+
+
 def test_async_final_result_reaches_generation_input_despite_tool_batch(
     hook_module,
     fake_langfuse,


### PR DESCRIPTION
## Why

`build_trace_metadata` carries `cwd` and `git_branch`, with the comment:

> Transcript rows carry the project dir and git branch so traces from different projects/worktrees are distinguishable in Langfuse.

On a multi-machine setup that goal is not met. Two hosts with the same checkout layout produce a **byte-identical `cwd`**, so their traces are indistinguishable.

Measured on a three-host fleet sharing one Langfuse project: two Linux machines both report `cwd=/home/<user>/code/<repo>`, and nothing else in the trace separates them. A macOS host is distinguishable only by accident, because its paths begin `/Users`. "Is this machine sending traces?" is currently unanswerable from the project.

## What this does

Adds `hostname` beside the existing fields.

Read at hook time via `socket.gethostname()` rather than from the transcript, because transcript rows carry no host field — their keys are `cwd`, `gitBranch`, `sessionId`, `version`, `entrypoint` and friends.

## The consequence, stated rather than discovered

That choice means the field names the host that **emitted** the trace. Normally that is the host that ran the session — but not when a stored transcript is re-processed elsewhere (a backfill, or a transcript copied to another machine for debugging). Then the value would be confidently wrong, which is worse than absent.

So the comment says which of the two it means. If Claude Code ever records a host in the transcript, that should be preferred and this kept as the fallback.

## Failure behaviour

`get_hostname_for_metadata` never raises. This runs on every turn, so an exception while building metadata would cost the entire trace rather than one field. An unreadable hostname degrades to a missing key.

## Tests

Two, in `tests/unit/test_langfuse_payload_builders.py` beside the existing metadata tests:

- `test_trace_metadata_names_the_emitting_host`
- `test_trace_metadata_survives_an_unreadable_hostname` — **watched failing**: removing the `try/except` makes it raise `OSError` rather than skip the key, so the guard is proven rather than assumed.

`uv run pytest` — 200 passed.

## Alternative considered and rejected

Setting `OTEL_RESOURCE_ATTRIBUTES=host.name=<host>` in Claude Code's settings `env` block. **Measured: it does not work.** Claude Code applies that block selectively and filters the `OTEL_*` namespace — an arbitrary invented variable passes through to the session while `OTEL_RESOURCE_ATTRIBUTES` and `OTEL_SERVICE_NAME` arrive empty. It fails silently, which is why `service.name: unknown_service` appears on every trace we have. There is no configuration-only route to this.