### PR TITLE
Add httpx[socks] to fix hook failure under SOCKS proxy

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #   "langfuse>=4.7,<5",
+#   "httpx[socks]",
 # ]
 # ///
 """


### PR DESCRIPTION
## Problem
When `ALL_PROXY`/`all_proxy` is set to a `socks5://` URL (a common setup alongside `HTTP_PROXY`/`HTTPS_PROXY`, e.g. via Clash/sing-box mixed ports), Langfuse client creation fails silently every turn with:
```
ImportError: Using SOCKS proxy, but the 'socksio' package is not installed.
```
Since the hook's PEP 723 dependency block only declares `langfuse`, uv's isolated script environment never installs `socksio`, and the failure is swallowed by the fail-open design (logged to `~/.claude/state/langfuse_hook.log`, turn continues normally). Users under a SOCKS proxy get zero traces exported with no visible error.

## Fix
Add `httpx[socks]` to the script's inline dependency block so `socksio` is installed automatically.

## Testing
Verified locally: reproduced the ImportError with the proxy env vars set, confirmed the patched dependency block resolves it (`Langfuse(...)` client construction succeeds under the same proxy env).