### PR TITLE
feat(hook): capture assistant thinking blocks as ChatML thinking parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ turn, so tracing needs no change to the way you work:
   under one session ID.
 - **Model generations**: every assistant message with inputs, outputs, cost and
   token usage, including cache-read and reasoning splits.
+- **Thinking**: assistant thinking blocks attach to the generation that produced
+  them and render as thinking blocks in the trace. Claude Code writes the
+  thinking text only when `showThinkingSummaries` is `true` in its settings.
 - **Tool calls**: each tool Claude Code invokes, with input and output.
 - **Subagents**: subagent and Workflow-spawned agent transcripts nest under the
   turn that started them.

--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1858,10 +1858,34 @@ def build_generation_input(
         return {"role": "tool", "tool_results": tool_results}
     return None
 
-def build_generation_output(assistant_text: str, tool_uses: List[Dict[str, Any]]) -> Dict[str, Any]:
+def build_thinking_parts(content: Any) -> Tuple[List[Dict[str, str]], List[Dict[str, Any]]]:
+    """Make ChatML thinking parts from the thinking blocks of an assistant message.
+
+    Langfuse renders these parts as thinking blocks. A block without text
+    holds no reasoning, so this function skips it.
+    """
+    parts: List[Dict[str, str]] = []
+    metas: List[Dict[str, Any]] = []
+    if not isinstance(content, list):
+        return parts, metas
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != "thinking":
+            continue
+        thinking_raw = block.get("thinking")
+        if not isinstance(thinking_raw, str) or not thinking_raw.strip():
+            continue
+        thinking_text, thinking_meta = truncate_text(thinking_raw)
+        parts.append({"type": "thinking", "content": thinking_text})
+        metas.append(thinking_meta)
+    return parts, metas
+
+def build_generation_output(assistant_text: str, tool_uses: List[Dict[str, Any]],
+                            thinking_parts: Optional[List[Dict[str, str]]] = None) -> Dict[str, Any]:
     output: Dict[str, Any] = {"role": "assistant"}
     if assistant_text:
         output["content"] = assistant_text
+    if thinking_parts:
+        output["thinking"] = thinking_parts
     if tool_uses:
         output["tool_calls"] = [
             {
@@ -2289,9 +2313,10 @@ def build_generation_kwargs(
     previous_tool_results: List[Dict[str, Any]],
     ready_async_tool_results: List[Dict[str, Any]],
 ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
-    assistant_text_raw = extract_text_from_content(get_content_from_row(assistant_message))
-    assistant_text, assistant_text_meta = truncate_text(assistant_text_raw)
-    tool_uses = get_tool_use_blocks(get_content_from_row(assistant_message))
+    assistant_content = get_content_from_row(assistant_message)
+    assistant_text, assistant_text_meta = truncate_text(extract_text_from_content(assistant_content))
+    tool_uses = get_tool_use_blocks(assistant_content)
+    thinking_parts, thinking_metas = build_thinking_parts(assistant_content)
 
     speed = get_speed_from_row(assistant_message)
 
@@ -2303,13 +2328,15 @@ def build_generation_kwargs(
             previous_tool_results,
             ready_async_tool_results,
         ),
-        output=build_generation_output(assistant_text, tool_uses),
+        output=build_generation_output(assistant_text, tool_uses, thinking_parts),
         metadata={
             "assistant_index": assistant_index,
             "assistant_text": assistant_text_meta,
             "tool_count": len(tool_uses),
         },
     )
+    if thinking_metas:
+        generation_kwargs["metadata"]["thinking"] = thinking_metas
     if speed is not None:
         generation_kwargs["metadata"]["speed"] = speed
     usage_details = get_usage_details_from_row(assistant_message)

--- a/tests/unit/test_thinking_capture.py
+++ b/tests/unit/test_thinking_capture.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+
+def thinking_block(text: str, signature: str = "sig-abc") -> dict:
+    return {"type": "thinking", "thinking": text, "signature": signature}
+
+
+def assistant_row(content: list) -> dict:
+    return {
+        "type": "assistant",
+        "message": {"role": "assistant", "id": "msg_1", "model": "claude-opus-5", "content": content},
+        "timestamp": "2026-01-01T00:00:01.000Z",
+    }
+
+
+def generation_kwargs(hook_module, content: list) -> dict:
+    kwargs, _ = hook_module.build_generation_kwargs(0, assistant_row(content), "do it", [], [])
+    return kwargs
+
+
+# ---- thinking parts ----
+
+def test_thinking_blocks_become_chatml_thinking_parts(hook_module):
+    kwargs = generation_kwargs(
+        hook_module,
+        [
+            thinking_block("The user wants the config path, so I read the settings file."),
+            {"type": "text", "text": "Reading the settings file."},
+            {"type": "tool_use", "id": "toolu_read", "name": "Read", "input": {"file_path": "settings.json"}},
+        ],
+    )
+
+    assert kwargs["output"] == {
+        "role": "assistant",
+        "content": "Reading the settings file.",
+        "thinking": [
+            {
+                "type": "thinking",
+                "content": "The user wants the config path, so I read the settings file.",
+            }
+        ],
+        "tool_calls": [{"id": "toolu_read", "name": "Read"}],
+    }
+    assert kwargs["metadata"]["thinking"] == [{"truncated": False, "orig_len": 60}]
+
+
+def test_thinking_text_stays_out_of_assistant_content(hook_module):
+    content = [thinking_block("secret reasoning"), {"type": "text", "text": "the answer"}]
+
+    assert hook_module.extract_text_from_content(content) == "the answer"
+    assert generation_kwargs(hook_module, content)["output"]["content"] == "the answer"
+
+
+def test_interleaved_thinking_blocks_keep_transcript_order(hook_module):
+    # Claude Code splits one assistant message across rows, so a merged
+    # message can hold more than one thinking block.
+    parts, metas = hook_module.build_thinking_parts(
+        [
+            thinking_block("first thought"),
+            {"type": "tool_use", "id": "toolu_a", "name": "Bash", "input": {}},
+            thinking_block("second thought"),
+        ]
+    )
+
+    assert [part["content"] for part in parts] == ["first thought", "second thought"]
+    assert len(metas) == 2
+
+
+def test_thinking_only_message_keeps_the_reasoning(hook_module):
+    output = generation_kwargs(hook_module, [thinking_block("only reasoning")])["output"]
+
+    assert output == {"role": "assistant", "thinking": [{"type": "thinking", "content": "only reasoning"}]}
+
+
+# ---- blocks that hold no reasoning ----
+
+def test_blocks_without_thinking_text_are_skipped(hook_module):
+    # Claude Code writes the block with an empty text when the
+    # showThinkingSummaries setting is off.
+    kwargs = generation_kwargs(
+        hook_module,
+        [
+            thinking_block(""),
+            thinking_block("   \n  "),
+            {"type": "thinking", "signature": "sig-only"},
+            {"type": "thinking", "thinking": {"not": "a string"}},
+            {"type": "text", "text": "the answer"},
+        ],
+    )
+
+    assert kwargs["output"] == {"role": "assistant", "content": "the answer"}
+    assert "thinking" not in kwargs["metadata"]
+
+
+def test_thinking_parts_of_string_content_are_empty(hook_module):
+    assert hook_module.build_thinking_parts("plain string content") == ([], [])
+    assert hook_module.build_thinking_parts(None) == ([], [])
+
+
+# ---- truncation ----
+
+def test_long_thinking_is_truncated_and_recorded(hook_module):
+    long_thinking = "t" * (hook_module.MAX_CHARS + 500)
+    kwargs = generation_kwargs(hook_module, [thinking_block(long_thinking)])
+
+    part = kwargs["output"]["thinking"][0]
+    assert len(part["content"]) == hook_module.MAX_CHARS
+    meta = kwargs["metadata"]["thinking"][0]
+    assert meta["truncated"] is True
+    assert meta["orig_len"] == len(long_thinking)
+    assert meta["kept_len"] == hook_module.MAX_CHARS
+
+
+# ---- signature ----
+
+def test_thinking_signature_is_not_traced(hook_module):
+    parts, _ = hook_module.build_thinking_parts([thinking_block("reasoning", signature="long-attestation-blob")])
+
+    assert parts == [{"type": "thinking", "content": "reasoning"}]


### PR DESCRIPTION
Closes #39. Linear: [LFE-14428](https://linear.app/clickhouse/issue/LFE-14428/feature-request-capture-assistant-thinking-blocks-reasoning-summaries)

## Problem

The hook dropped assistant reasoning. `extract_text_from_content()` collects only `type == "text"` blocks, so `thinking` blocks never reached a generation payload.

## Change

`build_thinking_parts()` maps thinking blocks to the ChatML shape Langfuse
already supports, and `build_generation_kwargs()` attaches it to the generation
that produced it:

```json
"output": {
  "role": "assistant",
  "content": "…",
  "thinking": [{"type": "thinking", "content": "<reasoning>"}]
},
"metadata": {"thinking": [{"truncated": false, "orig_len": 158}]}
```

- Empty or whitespace-only blocks are skipped, so traces of sessions without thinking summaries look exactly as before.
- Each block goes through `truncate_text()`, so `CC_LANGFUSE_MAX_CHARS` bounds it and the truncation info is visible in `metadata.thinking`.
- The `signature` attestation blob is not traced; only the reasoning text is.
- Subagent and Workflow-agent generations are covered, because they use the same `build_generation_kwargs()`.
- Usage and cost are untouched. `get_usage_details_from_row()` is unchanged and Anthropic reports thinking tokens inside the inclusive `output_tokens` bucket.

## Verification

End-to-end against Langfuse Cloud, hook invoked the way production does (`uv run --script`, hook payload on stdin, isolated `CC_LANGFUSE_STATE_DIR`):

Tests: `tests/unit/test_thinking_capture.py` (8 cases — parts on the output, interleaved blocks in transcript order, thinking kept out of `content`, empty and malformed blocks skipped, truncation recorded, signature not traced). 6 of the 8 fail without the change. Full suite: 206 passed.

## Not in this change

- `redacted_thinking` blocks. Langfuse supports them, but did not find any case to reproduce locally.
- The native "Thinking" widget appears only on assistant messages that Langfuse
  parses as ChatML. On generations with tool calls the reasoning is fully visible
  in the JSON view, but not in the widget: Langfuse renders tool calls only in
  the nested `{id, type, function: {name}}` shape, while the plugin emits a flat
  `{id, name}` pair, and that makes the whole assistant message fall back.
  Verified against Langfuse Cloud v4.27.0 with controlled payload variants. The
  gap is pre-existing and independent of this change; a follow-up fixes the shape
  in five lines.
