### PR TITLE
fix(hook): emit tool calls in the nested shape Langfuse renders

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -1863,10 +1863,13 @@ def build_generation_output(assistant_text: str, tool_uses: List[Dict[str, Any]]
     if assistant_text:
         output["content"] = assistant_text
     if tool_uses:
+        # Langfuse renders tool calls only in this nested shape. A flat
+        # id and name pair stays raw JSON in the trace UI.
         output["tool_calls"] = [
             {
                 "id": tool_use.get("id"),
-                "name": tool_use.get("name"),
+                "type": "function",
+                "function": {"name": tool_use.get("name")},
             }
             for tool_use in tool_uses
         ]

--- a/tests/unit/test_langfuse_payload_builders.py
+++ b/tests/unit/test_langfuse_payload_builders.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 
 def test_generation_input_tracks_user_tool_and_async_tool_contexts(hook_module):
     assert hook_module.build_generation_input(0, "hello", [], []) == {
@@ -48,8 +50,37 @@ def test_generation_output_lists_tool_calls_without_full_tool_input(hook_module)
     assert output == {
         "role": "assistant",
         "content": "I will read it.",
-        "tool_calls": [{"id": "toolu_read", "name": "Read"}],
+        "tool_calls": [
+            {"id": "toolu_read", "type": "function", "function": {"name": "Read"}}
+        ],
     }
+    assert "README.md" not in json.dumps(output)
+
+
+def test_generation_output_keeps_the_order_of_parallel_tool_calls(hook_module):
+    output = hook_module.build_generation_output(
+        "",
+        [
+            {"id": "toolu_a", "name": "Bash", "input": {"command": "ls"}},
+            {"id": "toolu_b", "name": "Read", "input": {"file_path": "a.py"}},
+        ],
+    )
+
+    assert output == {
+        "role": "assistant",
+        "tool_calls": [
+            {"id": "toolu_a", "type": "function", "function": {"name": "Bash"}},
+            {"id": "toolu_b", "type": "function", "function": {"name": "Read"}},
+        ],
+    }
+
+
+def test_generation_output_of_malformed_tool_use_keeps_the_nested_shape(hook_module):
+    output = hook_module.build_generation_output("", [{}])
+
+    assert output["tool_calls"] == [
+        {"id": None, "type": "function", "function": {"name": None}}
+    ]
 
 
 def test_tool_result_payload_preserves_initial_and_final_async_outputs(hook_module):


### PR DESCRIPTION
Linear: [LFE-15871](https://linear.app/clickhouse/issue/LFE-15871/bugclaude-plugin-flat-tool-calls-shape-makes-the-assistant-message)

## Problem

Every generation with tool calls shows its assistant message as a raw JSON table in the trace UI. No tool call cards, and no thinking blocks either. The reason is the shape: `tool_calls: [{id, name}]` fails Langfuse's ChatML validation, so
the whole message falls back to a `{role, json}` JSON view.

## Change

Adjusted `build_generation_output()`:

```python
output["tool_calls"] = [
    {
        "id": tool_use.get("id"),
        "type": "function",
        "function": {"name": tool_use.get("name")},
    }
    for tool_use in tool_uses
]
```

The tool input stays out of the generation payload, as before. `arguments` is
optional for the renderer, and the `Tool: <name>` observation already holds the
full input. 

## Verification

End-to-end against Langfuse Cloud, hook invoked the way production does (`uv run --script`, hook payload on stdin, isolated `CC_LANGFUSE_STATE_DIR`), against a real transcript: the assistant message now renders as a chat message with a `Bash` tool call card carrying the call id.

Robustness scan over 247 real transcripts: 3.563 tool calls, shape invariants
hold on every one, no exceptions.

Tests: 3 cases in `tests/unit/test_langfuse_payload_builders.py` (nested shape and
no tool input in the payload, parallel tool call order, malformed `tool_use`).
All 3 fail without the change. Full suite: 200 passed.

## Note

This pairs with the thinking capture in #76: with both changes the native "Thinking" block appears on the 86 % of reasoning generations that have tool calls and show a JSON table today.

