### PR TITLE
fix(hook): restore logging when keys are missing instead of silent fail

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -3096,7 +3096,7 @@ def main() -> int:
 
     config = get_langfuse_config()
     if config is None:
-        debug("No LANGFUSE_PUBLIC_KEY/SECRET_KEY in environment; nothing to do")
+        log_missing_langfuse_config()
         return 0
 
     payload = read_hook_payload()

--- a/tests/unit/test_config_visibility.py
+++ b/tests/unit/test_config_visibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from typing import Any
 
@@ -128,3 +129,26 @@ def test_client_creation_failure_is_logged(hook_module: Any, monkeypatch: pytest
     log = _read_log(hook_module)
     assert "Langfuse client creation failed" in log
     assert "RuntimeError" in log
+
+
+# ----------------- the reason reaches the log through main() -----------------
+
+def test_main_logs_incomplete_config_without_debug(
+    hook_module: Any, clean_key_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Covers the call path, not only the function: main() must log the reason.
+
+    The tests above call log_missing_langfuse_config() directly, so they stay
+    green even when main() stops calling it and users get silence.
+    """
+    monkeypatch.setattr(hook_module, "DEBUG", False)
+    monkeypatch.setattr("sys.stdin", io.StringIO("{}"))
+
+    assert hook_module.main() == 0
+
+    # Read tolerantly: without the call, no line is written and the log file is
+    # absent, which must fail as a readable assertion, not as a file error.
+    log_file = Path(hook_module.LOG_FILE)
+    log = log_file.read_text(encoding="utf-8") if log_file.exists() else ""
+    assert "[INFO]" in log, "main() wrote no log line: the reason stays invisible"
+    assert "Langfuse config incomplete" in log


### PR DESCRIPTION
## What happens

`log_missing_langfuse_config()` has no caller in production code — only the 6 call sites in `tests/unit/test_config_visibility.py` call it. In `main()`, the `config is None` branch logs at DEBUG instead, so an installation without keys produces **no log line at all** and the log file is not even created.

Reproduced with a real hook run on `main` (state dir redirected, no keys in the environment):

| Run | Result |
| --- | --- |
| no keys, no debug | no log file at all |
| no keys, `CC_LANGFUSE_DEBUG=true` | only `[DEBUG] Hook started` + `[DEBUG] No LANGFUSE_PUBLIC_KEY/SECRET_KEY…` |

`Langfuse config incomplete` appears in neither run.

## Change

- `hooks/langfuse_hook.py`: `main()` calls `log_missing_langfuse_config()` again instead of the DEBUG line. One line.
- `tests/unit/test_config_visibility.py`: a regression test that drives `main()` with the keys removed and `DEBUG` off, and reads the log file tolerantly so a missing file fails as a readable assertion rather than a file error.

No README change: the documentation becomes correct again on its own.

## Verification

- the new test is red without the fix (`main() wrote no log line: the reason stays invisible` / `assert '[INFO]' in ''`), green with it
- full suite: **199 passed**
- real hook run after the fix logs `[INFO] Langfuse config incomplete: missing LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY (checked CLAUDE_PLUGIN_OPTION_* and plain env vars); tracing disabled for this turn.`
- with a simulated inline identity it appends `Note: this hook was loaded under plugin identity '@inline'; …`, so the documented desktop detection path works

## Notes

Linear: [LFE-15872](https://linear.app/clickhouse/issue/LFE-15872/bugclaude-plugin-missing-keys-diagnostic-never-reaches-the-log-log)
