### PR TITLE
feat(hook): tag skills loaded by reading their SKILL.md, not only Skill tool invokes

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import random
+import re
 import sys
 import threading
 import time
@@ -1796,13 +1797,20 @@ def _start_backdated(langfuse: Langfuse, *, name: str, as_type: str,
     )
 
 # ---- Trace naming and tags ----
+# Matches the SKILL.md read path of a skill directory, e.g.
+# ~/.claude/skills/<name>/SKILL.md or any .../skills/<name>/SKILL.md.
+SKILL_MD_PATH_RE = re.compile(r"(?:^|/)skills/([A-Za-z0-9_.-]+)/SKILL\.md$")
+
+
 def add_skill_tags_from_rows(rows: List[Dict[str, Any]], names: List[str], prefix: str) -> None:
     """Collect '<prefix><name>' tags for every skill trail in the rows.
 
-    Skills leave two different transcript trails: a tool_use block named
-    "Skill" when Claude invokes the skill itself, and a top-level
+    Skills leave three different transcript trails: a tool_use block named
+    "Skill" when Claude invokes the skill itself, a top-level
     attributionSkill field on assistant rows when the user invokes it as a
-    slash command (which never produces a Skill tool_use block).
+    slash command (which never produces a Skill tool_use block), and a Read
+    tool_use whose file_path is a skill's SKILL.md (how dependency
+    sub-skills referenced from another skill's body get loaded).
     """
     def add_skill(skill: Any) -> None:
         if isinstance(skill, str) and skill and f"{prefix}{skill}" not in names:
@@ -1813,10 +1821,18 @@ def add_skill_tags_from_rows(rows: List[Dict[str, Any]], names: List[str], prefi
             continue
         add_skill(row.get("attributionSkill"))
         for tool_use in get_tool_use_blocks(get_content_from_row(row)):
-            if tool_use.get("name") != "Skill":
-                continue
             tool_input = tool_use.get("input")
-            add_skill(tool_input.get("skill") if isinstance(tool_input, dict) else None)
+            if not isinstance(tool_input, dict):
+                continue
+            tool_name = tool_use.get("name")
+            if tool_name == "Skill":
+                add_skill(tool_input.get("skill"))
+            elif tool_name == "Read":
+                file_path = tool_input.get("file_path")
+                if isinstance(file_path, str):
+                    match = SKILL_MD_PATH_RE.search(file_path)
+                    if match:
+                        add_skill(match.group(1))
 
 
 def collect_skill_tags(turn: Turn) -> List[str]:

--- a/tests/unit/test_skill_tags.py
+++ b/tests/unit/test_skill_tags.py
@@ -172,3 +172,55 @@ def test_same_skill_across_two_subagents_is_tagged_once(hook_module, tmp_path):
     assert hook_module.collect_subagent_skill_tags(turns[0], sub_map) == [
         "subagent-skill:deep-research",
     ]
+
+
+def make_read_tool_use_row(file_path: str, uuid: str = "assistant-read") -> dict[str, Any]:
+    """Invocation path 3: a dependency sub-skill loaded by reading its
+    SKILL.md directly (referenced from another skill's body)."""
+    return {
+        "type": "assistant",
+        "timestamp": "2026-01-01T00:00:03.000Z",
+        "uuid": uuid,
+        "message": {
+            "id": f"msg-{uuid}",
+            "role": "assistant",
+            "model": "claude-test",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": f"toolu_{uuid}",
+                    "name": "Read",
+                    "input": {"file_path": file_path},
+                }
+            ],
+        },
+    }
+
+
+def test_skill_loaded_via_read_of_skill_md_is_tagged(hook_module):
+    rows = [
+        make_user_row("commit this"),
+        make_read_tool_use_row("/Users/u/.claude/skills/shell-quoting-pitfalls/SKILL.md"),
+    ]
+
+    assert collect_tags(hook_module, rows) == ["skill:shell-quoting-pitfalls"]
+
+
+def test_read_of_non_skill_file_is_not_tagged(hook_module):
+    rows = [
+        make_user_row("read these"),
+        make_read_tool_use_row("/Users/u/project/src/main.py", uuid="assistant-read-1"),
+        make_read_tool_use_row("/Users/u/.claude/skills/foo/references/cli.md", uuid="assistant-read-2"),
+    ]
+
+    assert collect_tags(hook_module, rows) == []
+
+
+def test_read_and_invoke_of_same_skill_dedupes(hook_module):
+    rows = [
+        make_user_row("use the skill"),
+        make_skill_tool_use_row("langfuse"),
+        make_read_tool_use_row("/Users/u/.claude/skills/langfuse/SKILL.md"),
+    ]
+
+    assert collect_tags(hook_module, rows) == ["skill:langfuse"]


### PR DESCRIPTION
## Problem

`collect_skill_tags` covers two skill trails: a `Skill` tool_use block, and `attributionSkill` on assistant rows (slash commands). There is a third trail it misses: **dependency sub-skills loaded by reading their `SKILL.md` directly** with the `Read` tool, which is how a skill referenced from another skill's body ("REQUIRED SUB-SKILL: …", "See skills/foo/SKILL.md") typically gets loaded.

Measured on my local transcripts over 4 weeks: a commit-workflow skill that marks a shell-quoting sub-skill as required was invoked 33 times, while the sub-skill collected **0** `skill:` tags — it was only ever loaded via `Read`. A sibling Codex setup that counts raw `SKILL.md` reads saw the same sub-skill in 32 sessions over the same period. Tag-based usage analytics therefore undercount exactly the skills that only ever run as dependencies, and "which skills can I safely disable?" queries give a false zero for them.

## Change

`add_skill_tags_from_rows` now recognizes the third trail: a `Read` tool_use whose `file_path` matches `(^|/)skills/<name>/SKILL.md$` adds the same `skill:<name>` tag.

- The regex is anchored on the `SKILL.md` filename, so reads of `skills/<name>/references/*.md` or other files inside a skill directory do **not** tag.
- Dedup is unchanged (a turn that both invokes and reads the same skill yields one tag).
- Subagent rows flow through the same helper, so the `subagent-skill:` namespace picks the trail up as well.
- Still gated behind the existing `CC_LANGFUSE_SKILL_TAGS` option; no new configuration.

## Verification

Three new unit tests in `tests/unit/test_skill_tags.py`:

| Test | Pins |
|---|---|
| `test_skill_loaded_via_read_of_skill_md_is_tagged` | the new trail |
| `test_read_of_non_skill_file_is_not_tagged` | ordinary reads and `references/*` reads stay untagged |
| `test_read_and_invoke_of_same_skill_dedupes` | one tag per skill per turn |

Full suite: **223 passed**.

End to end: a headless `claude -p` session instructed to only `Read` a skill's `SKILL.md` (no Skill invoke) produced a trace tagged `['claude-code', 'skill:goal-first']`, confirmed through the metrics API on the `tags` dimension against a live Langfuse project.
