### PR TITLE
test(hook): update stale tool_calls expectations after #77

### DIFF
--- a/tests/integration/test_generation_history.py
+++ b/tests/integration/test_generation_history.py
@@ -154,7 +154,9 @@ def test_generation_input_within_turn_contains_tool_steps(
     # Second generation of turn 1: user, tool-call assistant, tool results.
     second = inputs[1]
     assert [m.get("role") for m in second] == ["user", "assistant", "tool"]
-    assert second[1]["tool_calls"] == [{"id": "toolu-1", "name": "Read"}]
+    assert second[1]["tool_calls"] == [
+        {"id": "toolu-1", "type": "function", "function": {"name": "Read"}}
+    ]
     assert second[2]["tool_results"][0]["tool_use_id"] == "toolu-1"
     # Turn 2 sees the full tool exchange of turn 1.
     third = inputs[2]
@@ -412,3 +414,66 @@ def test_workflow_agent_generations_carry_history(
         assert isinstance(generation_input, list)
     for generation in generations(fake_langfuse):
         assert "history" in generation.kwargs["metadata"]
+
+
+# ---- tool_calls shape: one producer, every path ----
+
+def test_history_tool_calls_come_from_the_one_shape_builder(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    """Pins the history path to build_generation_output."""
+    transcript = tmp_path / f"{SESSION}.jsonl"
+    write_rows(transcript, tool_turn_rows(SESSION, 1) + simple_turn_rows(SESSION, 2))
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config_for(hook_module), SESSION, transcript
+    )
+
+    expected = hook_module.build_generation_output("", [{"id": "toolu-1", "name": "Read"}])
+    live_generation = generation_inputs(fake_langfuse)[1][1]
+    later_turn_history = generation_inputs(fake_langfuse)[2][1]
+
+    assert live_generation["tool_calls"] == expected["tool_calls"]
+    assert later_turn_history["tool_calls"] == expected["tool_calls"]
+
+
+def test_every_tool_call_the_hook_emits_has_the_nested_keys(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = tmp_path / f"{SESSION}.jsonl"
+    write_rows(transcript, tool_turn_rows(SESSION, 1) + tool_turn_rows(SESSION, 2))
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config_for(hook_module), SESSION, transcript
+    )
+
+    seen = 0
+    for messages in generation_inputs(fake_langfuse):
+        for message in messages or []:
+            for tool_call in (message or {}).get("tool_calls", []):
+                assert set(tool_call) == {"id", "type", "function"}
+                assert tool_call["type"] == "function"
+                assert set(tool_call["function"]) == {"name"}
+                seen += 1
+    assert seen > 0, "no tool_calls reached the history, the assertion proved nothing"
+
+
+def test_a_tool_use_without_a_name_keeps_the_nested_shape_in_the_history(
+    hook_module, fake_langfuse, isolated_hook_state, tmp_path
+):
+    transcript = tmp_path / f"{SESSION}.jsonl"
+    write_rows(transcript, [
+        user_row(SESSION, 1, "Question 1?"),
+        assistant_row(SESSION, 1, [{"type": "tool_use", "id": "toolu-x"}], part=0),
+        tool_result_row(SESSION, 1, "toolu-x", "result"),
+        assistant_row(SESSION, 1, [{"type": "text", "text": "Answer 1."}], part=1),
+        *simple_turn_rows(SESSION, 2),
+    ])
+
+    hook_module.emit_new_turns_from_transcript(
+        fake_langfuse, config_for(hook_module), SESSION, transcript
+    )
+
+    assert generation_inputs(fake_langfuse)[1][1]["tool_calls"] == [
+        {"id": "toolu-x", "type": "function", "function": {"name": None}}
+    ]

--- a/tests/unit/test_thinking_capture.py
+++ b/tests/unit/test_thinking_capture.py
@@ -39,7 +39,7 @@ def test_thinking_blocks_become_chatml_thinking_parts(hook_module):
                 "content": "The user wants the config path, so I read the settings file.",
             }
         ],
-        "tool_calls": [{"id": "toolu_read", "name": "Read"}],
+        "tool_calls": [{"id": "toolu_read", "type": "function", "function": {"name": "Read"}}],
     }
     assert kwargs["metadata"]["thinking"] == [{"truncated": False, "orig_len": 60}]
 
@@ -117,3 +117,36 @@ def test_thinking_signature_is_not_traced(hook_module):
     parts, _ = hook_module.build_thinking_parts([thinking_block("reasoning", signature="long-attestation-blob")])
 
     assert parts == [{"type": "thinking", "content": "reasoning"}]
+
+
+def test_thinking_sits_beside_parallel_tool_calls(hook_module):
+    kwargs = generation_kwargs(
+        hook_module,
+        [
+            thinking_block("Two files to read, so two calls."),
+            {"type": "tool_use", "id": "toolu_a", "name": "Read", "input": {"file_path": "a.py"}},
+            {"type": "tool_use", "id": "toolu_b", "name": "Read", "input": {"file_path": "b.py"}},
+        ],
+    )
+
+    assert kwargs["output"]["thinking"] == [
+        {"type": "thinking", "content": "Two files to read, so two calls."}
+    ]
+    assert kwargs["output"]["tool_calls"] == [
+        {"id": "toolu_a", "type": "function", "function": {"name": "Read"}},
+        {"id": "toolu_b", "type": "function", "function": {"name": "Read"}},
+    ]
+    # A message of only thinking and tool_use extracts no text.
+    assert "content" not in kwargs["output"]
+
+
+def test_thinking_and_tool_calls_use_the_shared_shape_builder(hook_module):
+    content = [
+        thinking_block("Reading it."),
+        {"type": "tool_use", "id": "toolu_read", "name": "Read", "input": {"file_path": "a.py"}},
+    ]
+
+    kwargs = generation_kwargs(hook_module, content)
+    expected = hook_module.build_generation_output("", [{"id": "toolu_read", "name": "Read"}])
+
+    assert kwargs["output"]["tool_calls"] == expected["tool_calls"]


### PR DESCRIPTION
## What

The nested `tool_calls` shape landed in #77, but two expectations kept the flat `{id, name}` pair, so the suite has been red on `main` ever since. This updates both and adds coverage so the same drift fails loudly instead of silently.

**Tests only — the hook is unchanged.** 235 pass, up from 228 with 2 failing.

| | |
| --- | --- |
| `tests/unit/test_thinking_capture.py` | stale expectation, now nested |
| `tests/integration/test_generation_history.py` | stale expectation, now nested |

## The tests update

`build_generation_output()` is the only producer of `tool_calls`, and its own comment states the constraint:

> Langfuse renders tool calls only in this nested shape. A flat id and name pair stays raw JSON in the trace UI.

Verified again end to end against a live Langfuse: a parallel tool turn arrives with `{id, type: "function", function: {name}}` intact, order preserved, no server-side rewriting. So the fix is to move the expectations, not the shape.

Checked while here: all three history call sites route through that one builder (`build_turn_history_messages`, the live generation payload, and the per-step history append), so no second producer had drifted. The README says nothing about the shape.

## New coverage

- `test_every_tool_call_the_hook_emits_has_the_nested_keys` — a structural check over every `tool_call` the hook emits, independent of the builder. **This is the one that would have caught #77.**
- `test_history_tool_calls_come_from_the_one_shape_builder` and `test_thinking_and_tool_calls_use_the_shared_shape_builder` — parity checks that catch a second producer with a different shape, which is the risk with three history call sites.
- `test_a_tool_use_without_a_name_keeps_the_nested_shape_in_the_history` — a malformed `tool_use` carried through the history path; the builder had this case covered, the history did not.
- `test_thinking_sits_beside_parallel_tool_calls` — thinking with more than one tool call.

## Verifying the guard

Reintroducing the flat shape in the hook fails **8 tests** across all three layers (3 builder unit, 2 thinking, 3 history), then passes again once reverted. A guard that catches nothing is worth nothing, so this was checked explicitly.

## Not in scope

The missing CI that let this sit unnoticed. A workflow running `uv run pytest` on pull requests would prevent a repeat, but that is a separate change. -> see follow up pr

Linear: [LFE-16081](https://linear.app/clickhouse/issue/LFE-16081/gh-pr-testhook-update-stale-tool-calls-expectations-after-77)
