### PR TITLE
ci: add CI, release and workflow-security workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - name: Test
+        run: uv run --python ${{ matrix.python-version }} --group dev pytest
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - name: Ruff
+        run: uvx ruff check --select F,E9 .
+
+  hook-smoke:
+    name: Hook starts from its own script header
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - name: Run the hook with an empty payload
+        run: echo '{}' | uv run --script hooks/langfuse_hook.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Verify the tag and draft a GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Validate release version
+        run: |
+          manifest_version="$(python3 -c 'import json; print(json.load(open(".claude-plugin/plugin.json"))["version"])')"
+          if [[ "$GITHUB_REF_NAME" != "v$manifest_version" ]]; then
+            echo "Tag $GITHUB_REF_NAME does not match plugin.json version $manifest_version" >&2
+            exit 1
+          fi
+      - name: Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Test
+        run: uv run --group dev pytest
+      - name: Run the hook with an empty payload
+        run: echo '{}' | uv run --script hooks/langfuse_hook.py
+      # Draft, so the notes get a human pass before anyone sees them.
+      - name: Create draft GitHub release
+        run: gh release create "$GITHUB_REF_NAME" --draft --generate-notes --verify-tag
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Check GitHub Actions
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+  merge_group:
+  pull_request:
+    branches:
+      - "main"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Check GitHub Actions security
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        with:
+          # Findings upload to code scanning only on push; a pull request from a
+          # fork has no write token for it.
+          advanced-security: ${{ github.event_name == 'push' && 'true' || 'false' }}
+          min-severity: low


### PR DESCRIPTION
## What

Housekeeping. This repo had no `.github` directory at all, so nothing ran on a pull request. It is the only observability plugin without CI — opencode, codex and pi each ship `ci.yml` and `release.yml`, and two of them ship `zizmor.yml`.

Three workflows, all actions SHA-pinned, clean under both `zizmor` and `actionlint`:

| Workflow | Trigger | What it checks |
| --- | --- | --- |
| `ci.yml` | pull request, push to `main` | pytest on Python 3.10 and 3.13, ruff, and a smoke run of the hook |
| `zizmor.yml` | pull request, push to `main`, merge group, manual | workflow security scanning |
| `release.yml` | push of a `v*` tag | tag matches `plugin.json`, tests, then a draft release |

## Order

**Merge #85 first.** Otherwise the first CI run correctly reports the two stale `tool_calls` expectations that #85 fixes.

## Verification

Every job command was run locally, on this tree and on a tree with #85 applied:

- with `main` as it is: test red (the two known failures), lint green, smoke green
- with #85 applied: **235 passed on both Python versions**, lint green, smoke green
- the release version gate, exercised against the real manifest: `v1.1.0` accepted; `v1.0.0`, `v2.0.0` and `v1.1.0-rc.1` rejected
- `zizmor --min-severity low` over all three: *No findings to report*
- `actionlint` over all three: no findings

Note that prereleases are rejected by design: the marketplace installs from the repository, so there is no separate channel for one. The siblings need that only for npm dist-tags.

Linear: [LFE-16082](https://linear.app/clickhouse/issue/LFE-16082/gh-pr-ci-add-ci-release-and-workflow-security-workflows)
