### PR TITLE
chore(plugin): bump the version to 1.2.0 for release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "langfuse-observability",
   "description": "The Langfuse x Claude Code Observability Plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Langfuse"
   },


### PR DESCRIPTION
Maintainer needs to run `git tag v1.2.0 && git push origin` v1.2.0 after merging this PR