### PR TITLE
fix(hook): narrow the state lock so concurrent sessions keep their turns

### DIFF
--- a/hooks/langfuse_hook.py
+++ b/hooks/langfuse_hook.py
@@ -450,6 +450,10 @@ def is_session_end_hook_payload(payload: Dict[str, Any]) -> bool:
 
 
 # ----------------- State file concurrency control -----------------
+def get_session_lock_path(key: str) -> Path:
+    return STATE_DIR / f"langfuse_state.{key[:16]}.lock"
+
+
 class FileLock:
     def __init__(self, path: Path, timeout_s: float = 2.0):
         self.path = path
@@ -575,6 +579,23 @@ def update_session_state(global_state: Dict[str, Any], key: str, session_state: 
         "updated": datetime.now(timezone.utc).isoformat(),
     }
 
+def sweep_stale_session_locks(state: Dict[str, Any], cutoff: datetime) -> None:
+    live = {k[:16] for k in state if isinstance(k, str)}
+    try:
+        locks = list(STATE_DIR.glob("langfuse_state.*.lock"))
+    except OSError:
+        return
+    for lock in locks:
+        stem = lock.name[len("langfuse_state."):-len(".lock")]
+        if len(stem) != 16 or stem in live:
+            continue
+        try:
+            if lock.stat().st_mtime < cutoff.timestamp():
+                lock.unlink()
+        except OSError:
+            pass
+
+
 def save_hook_state(state: Dict[str, Any]) -> None:
     try:
         # Drop session entries older than 30 days to keep the file bounded.
@@ -592,6 +613,7 @@ def save_hook_state(state: Dict[str, Any]) -> None:
                 continue
             if ts < cutoff:
                 del state[k]
+        sweep_stale_session_locks(state, cutoff)
         STATE_DIR.mkdir(parents=True, exist_ok=True)
         tmp = STATE_FILE.with_suffix(".tmp")
         tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
@@ -3382,9 +3404,11 @@ def emit_new_turns_from_transcript(
     *,
     flush_deferred_agent_turns: bool = False,
 ) -> int:
-    with FileLock(LOCK_FILE):
-        state = load_hook_state()
-        key = get_session_state_key(session_id, str(transcript_path))
+    key = get_session_state_key(session_id, str(transcript_path))
+
+    with FileLock(get_session_lock_path(key)):
+        with FileLock(LOCK_FILE):
+            state = load_hook_state()
         session_state = get_session_state(state, key)
 
         subagent_transcripts_by_tool_use_id = get_subagent_transcripts_by_tool_use_id(transcript_path)
@@ -3453,7 +3477,9 @@ def emit_new_turns_from_transcript(
         # duplicate window): progress is persisted before the SDK flush in
         # main(); a dropped flush leaves emitted_keys pointing at spans that
         # never reached the server.
-        save_session_state(state, key, session_state)
+        with FileLock(LOCK_FILE):
+            state = load_hook_state()
+            save_session_state(state, key, session_state)
 
     return emitted
 
@@ -3519,7 +3545,7 @@ def main() -> int:
         return 0
 
     except TimeoutError as e:
-        debug(f"lock timeout, skipping: {e}")
+        info(f"lock timeout, skipping: {e}")
         return 0
 
     except Exception as e:

--- a/tests/integration/test_state_lock_contention.py
+++ b/tests/integration/test_state_lock_contention.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _run_emit(hook_module: Any, fake_langfuse: Any, session_id: str, transcript: Path) -> int:
+    config = hook_module.LangfuseConfig("public", "secret", "https://example.test", "user-1")
+    return hook_module.emit_new_turns_from_transcript(
+        fake_langfuse,
+        config,
+        session_id,
+        transcript,
+        flush_deferred_agent_turns=True,
+    )
+
+
+def _during_emit(hook_module: Any, monkeypatch: pytest.MonkeyPatch, callback: Any) -> None:
+    """Run callback in the middle of the emit, where the old code held the lock."""
+    original = hook_module.emit_and_close_ready_turns
+
+    def wrapped(*args: Any, **kwargs: Any) -> int:
+        callback()
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(hook_module, "emit_and_close_ready_turns", wrapped)
+
+
+def test_emit_leaves_the_global_lock_free(
+    hook_module: Any,
+    fixture_transcript_path: Any,
+    fake_langfuse: Any,
+    isolated_hook_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The emit must not hold the global lock, or a second session is starved.
+
+    The emit takes seconds on a large transcript. While the global lock covered
+    it, every other session waited for the whole emit, gave up and dropped its
+    turn without a trace in the log.
+    """
+    acquired: list[bool] = []
+
+    def try_global_lock() -> None:
+        try:
+            with hook_module.FileLock(hook_module.LOCK_FILE, timeout_s=0.05):
+                acquired.append(True)
+        except TimeoutError:
+            acquired.append(False)
+
+    _during_emit(hook_module, monkeypatch, try_global_lock)
+
+    emitted = _run_emit(hook_module, fake_langfuse, "session-simple", fixture_transcript_path("simple_turn"))
+
+    assert emitted == 1
+    assert acquired == [True], "the global lock was held across the emit"
+
+
+def test_the_session_lock_is_held_across_the_emit(
+    hook_module: Any,
+    fixture_transcript_path: Any,
+    fake_langfuse: Any,
+    isolated_hook_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One session still may not emit twice at the same time.
+
+    Narrowing the global lock must not drop that guarantee: two firings of the
+    same session would read one offset and emit the same turn twice.
+    """
+    acquired: list[bool] = []
+    key = hook_module.get_session_state_key("session-simple", str(fixture_transcript_path("simple_turn")))
+
+    def try_session_lock() -> None:
+        try:
+            with hook_module.FileLock(hook_module.get_session_lock_path(key), timeout_s=0.05):
+                acquired.append(True)
+        except TimeoutError:
+            acquired.append(False)
+
+    _during_emit(hook_module, monkeypatch, try_session_lock)
+
+    _run_emit(hook_module, fake_langfuse, "session-simple", fixture_transcript_path("simple_turn"))
+
+    assert acquired == [False], "a second firing of the same session could emit in parallel"
+
+
+def test_entry_of_another_session_survives_the_emit(
+    hook_module: Any,
+    fixture_transcript_path: Any,
+    fake_langfuse: Any,
+    isolated_hook_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The write must re-read the file, or it deletes a concurrent entry.
+
+    The state file holds every session. A session that saves from the copy it
+    loaded before its emit writes back a file without the entries that other
+    sessions saved meanwhile.
+    """
+    def other_session_saves() -> None:
+        with hook_module.FileLock(hook_module.LOCK_FILE):
+            state = hook_module.load_hook_state()
+            state["other-session-key"] = {"offset": 42, "updated": "2026-09-10T00:00:00+00:00"}
+            hook_module.save_hook_state(state)
+
+    _during_emit(hook_module, monkeypatch, other_session_saves)
+
+    _run_emit(hook_module, fake_langfuse, "session-simple", fixture_transcript_path("simple_turn"))
+
+    state = json.loads((isolated_hook_state / "langfuse_state.json").read_text(encoding="utf-8"))
+    assert "other-session-key" in state, "the emit deleted the entry of a concurrent session"
+    assert len(state) == 2, "the session under test did not save its own entry"
+
+
+def _age(path: Path, days: int) -> None:
+    stamp = (datetime.now(timezone.utc) - timedelta(days=days)).timestamp()
+    os.utime(path, (stamp, stamp))
+
+
+def test_a_stale_session_lock_file_is_swept(hook_module: Any, isolated_hook_state: Path) -> None:
+    """A run that fails before it saves leaves a lock file with no entry to prune it."""
+    orphan = hook_module.get_session_lock_path("a" * 64)
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.touch()
+    _age(orphan, 365)
+
+    hook_module.save_hook_state({})
+
+    assert not orphan.exists(), "orphaned lock files accumulate in the state directory forever"
+
+
+def test_a_fresh_session_lock_file_is_never_swept(
+    hook_module: Any, isolated_hook_state: Path
+) -> None:
+    """The sweep must not delete a lock a running session still holds.
+
+    Deleting it lets the next run of that session create its own file and take a
+    second, independent lock, so the session would emit twice in parallel.
+    """
+    running = hook_module.get_session_lock_path("b" * 64)
+    running.parent.mkdir(parents=True, exist_ok=True)
+    running.touch()
+
+    hook_module.save_hook_state({})
+
+    assert running.exists(), "the sweep deleted a lock file that a live run may hold"
+
+
+def test_the_sweep_keeps_the_lock_of_a_live_entry(
+    hook_module: Any, isolated_hook_state: Path
+) -> None:
+    """An old lock file still belonging to a live state entry stays."""
+    key = "c" * 64
+    lock_path = hook_module.get_session_lock_path(key)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch()
+    _age(lock_path, 365)
+
+    hook_module.save_hook_state({key: {"offset": 1, "updated": _now_iso()}})
+
+    assert lock_path.exists(), "the sweep removed the lock file of a live session"
+
+
+def test_the_sweep_leaves_the_global_lock_alone(
+    hook_module: Any, isolated_hook_state: Path
+) -> None:
+    """The global lock file must never be swept."""
+    global_lock = Path(hook_module.LOCK_FILE)
+    global_lock.parent.mkdir(parents=True, exist_ok=True)
+    global_lock.touch()
+    _age(global_lock, 365)
+
+    hook_module.save_hook_state({})
+
+    assert global_lock.exists(), "the sweep deleted the global lock file"
+
+
+def test_main_logs_a_lock_timeout_without_debug(
+    hook_module: Any, isolated_hook_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A skipped export must say so in the log under default settings.
+
+    The symptom reaches the user as missing data in Langfuse, while the cause
+    is local. At debug level the skip left no record at all.
+    """
+    monkeypatch.setattr(hook_module, "DEBUG", False)
+    monkeypatch.setattr(hook_module, "get_langfuse_config", lambda: hook_module.LangfuseConfig(
+        "public", "secret", "https://example.test", None
+    ))
+    monkeypatch.setattr(hook_module, "create_langfuse_client", lambda _config: object())
+    monkeypatch.setattr(hook_module, "flush_and_shutdown_langfuse_client", lambda _client: None)
+
+    def refuse(*_args: Any, **_kwargs: Any) -> int:
+        raise TimeoutError("could not acquire lock within 2.0s")
+
+    monkeypatch.setattr(hook_module, "emit_new_turns_from_transcript", refuse)
+
+    transcript = isolated_hook_state / "transcript.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text("", encoding="utf-8")
+    payload = json.dumps(
+        {"session_id": "s", "transcript_path": str(transcript), "hook_event_name": "Stop"}
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(payload))
+
+    assert hook_module.main() == 0
+
+    log_file = Path(hook_module.LOG_FILE)
+    log = log_file.read_text(encoding="utf-8") if log_file.exists() else ""
+    assert "[INFO]" in log, "the skip left no log line: the cause stays invisible"
+    assert "lock timeout" in log


### PR DESCRIPTION
Fixes #48.
Fixes LFE-14885.

## Problem

`emit_new_turns_from_transcript()` held the one global state lock across its whole body, the state read, the transcript parse, the span build and the state write.

A second concurrent session therefore exhausted the 2.0s acquisition timeout, `main()` caught the `TimeoutError`, logged it at `debug` and returned `0`. Under the default configuration `debug` is suppressed, so that session never parsed its transcript, never built a span, never exported anything, and left **no log line at all** while reporting success to Claude Code.

## What this PR changes

The one lock was guarding two things of very different size. The shared state file needs protection, but only for a read and a write. The emit needs no *global* protection at all, because each session writes only its own key.

- **A per-session lock** (`get_session_lock_path(key)` → `langfuse_state.<key[:16]>.lock`) spans the operation. Different sessions take different files and never wait on each other. A session still serialises against itself, so it cannot emit the same turn twice.
- **The global lock is held only across the state file read and write**. 
- **The write re-reads the state file inside the lock.** Sessions now genuinely run in parallel, and writing back a copy loaded before the emit deletes entries other sessions saved meanwhile. 
- **Stale session lock files are swept** on the existing 30-day prune, keyed on age. A run that fails after taking its lock and before saving state leaves a file no state entry would ever prune. 
- **A skipped export logs at `info`.** This half comes straight from #49; silent data loss under default settings is what made this hard to diagnose.

## What this does not fix

- The ~1.45s `SessionEnd` kill window itself. A single session that is slow there is still cut off; that is a separate problem from sessions waiting on each other.
- The upgrade window: while an *old* hook process still holds the global lock across a 6s emit, a new one waits only 2.0s and can still skip. This is transient, limited to a plugin update with live sessions, and untested.

## Testing

`uv run -m pytest` → **279 passed** (8 new in `tests/integration/test_state_lock_contention.py`), `ruff check --select F,E9` clean, Python 3.10 and 3.13, hook smoke with an empty payload exits 0.

The new tests are mutation-checked — all 8 fail on current `main`; removing the re-read fails exactly `test_entry_of_another_session_survives_the_emit`; removing the per-session lock fails exactly `test_the_session_lock_is_held_across_the_emit`. Useful detail for anyone extending them: `flock` conflicts between two file descriptors in one process, so contention is testable in-process without subprocesses.

End to end, with real hook processes and with real Claude Code against Langfuse Cloud:

- A real session on this branch exports normally: trace present, 2 observations, input and output set.
- Six concurrent real sessions sharing one state dir: all six entries survive, six per-session locks plus the global one, zero lock timeouts. (Reported honestly: this test does not have teeth for the re-read on its own — real sessions emit in ~0.02s and never hit the window. The control without the re-read passes it too.)
- Lost update, with an injected 6s emit: **without** the re-read the concurrent session's entry is deleted; **with** it both survive.
- The same session firing twice concurrently emits exactly one turn — fast case 1+0, overlapping case the second run hits the per-session lock timeout, logs at `info` and skips. No duplicates.
- Orphaned lock file: reproduced, then confirmed swept.

## Credit

@kamikaze011001 diagnosed this precisely, and opened #49. 